### PR TITLE
Vectorize kepler

### DIFF
--- a/contributors.txt
+++ b/contributors.txt
@@ -1,8 +1,5 @@
 Sarah Blunt -- collaboratively designed basic API
 
-Jason Wang -- collaboratively designed basic API
+Jason Wang -- collaboratively designed basic API, wrote kepler.py
 
-Henry Ngo -- wrote code to read inputs
-
-
-
+Henry Ngo -- wrote code to read inputs, kepler.py

--- a/orbitize/kepler.py
+++ b/orbitize/kepler.py
@@ -29,6 +29,8 @@ def calc_orbit(epochs, sma, ecc, tau, argp, lan, inc, plx, mtot, mass=0):
         raoff (np.array): 2-D array (n_orbs x n_dates) of RA offsets between the bodies (origin is at the other body)
         deoff (np.array): 2-D array (n_orbs x n_dates) of Dec offsets between the bodies
         vz (np.array): 2-D array (n_orbs x n_dates) of radial velocity offset between the bodies
+
+    Written: Jason Wang, Henry Ngo, 2018
     """
 
     n_orbs  = np.size(sma)  # num sets of input orbital parameters
@@ -125,6 +127,8 @@ def _calc_ecc_anom(manom, ecc, tolerance=1e-9, max_iter=100):
         max_iter (int, optional): maximum number of iterations before switching. Defaults to 100.
     Return:
         eanom (np.array): array of eccentric anomalies
+
+    Written: Jason Wang, 2018
     """
 
     if ecc == 0.0:
@@ -165,6 +169,8 @@ def _mikkola_solver_wrapper(manom, e):
         ecc (float): eccentricity
     Return:
         eccanom (np.array): array of eccentric anomalies
+
+    Written: Jason Wang, 2018
     """
     ind_change = np.where(manom > np.pi)
     manom[ind_change] = (2.0 * np.pi) - manom[ind_change]
@@ -183,6 +189,8 @@ def _mikkola_solver(manom, e):
         ecc (float): eccentricity
     Return:
         eccanom (np.array): array of eccentric anomalies
+
+    Written: Jason Wang, 2018
     """
 
     alpha = (1.0 - e) / ((4.0 * e) + 0.5)

--- a/orbitize/kepler.py
+++ b/orbitize/kepler.py
@@ -8,72 +8,89 @@ import astropy.constants as consts
 
 def calc_orbit(epochs, sma, ecc, tau, argp, lan, inc, plx, mtot, mass=0):
     """
-    Returns the separation and radial velocity of the body given orbital parameters
+    Returns the separation and radial velocity of the body given array of
+    orbital parameters (size n_orbs) at given epochs (array of size n_dates)
 
     Based on orbit solvers from James Graham and Rob De Rosa. Adapted by Jason Wang.
 
     Args:
-        epochs (np.array): 1-D array of MJD times for which we want the positions of the planet
-        sma (float): semi-major axis of orbit [au]
-        ecc (float): eccentricity of the orbit [0,1]
-        tau (float): epoch of periastron passage in fraction of orbital period past MJD=0 [0,1]
-        argp (float): argument of periastron [radians]
-        lan (float): longitude of the ascending node [radians]
-        inc (float): inclination [radians]
-        plx (float): parallax [mas]
-        mtot (float): total mass [Solar masses]. Note that this is
+        epochs (np.array): MJD times for which we want the positions of the planet
+        sma (np.array): semi-major axis of orbit [au]
+        ecc (np.array): eccentricity of the orbit [0,1]
+        tau (np.array): epoch of periastron passage in fraction of orbital period past MJD=0 [0,1]
+        argp (np.array): argument of periastron [radians]
+        lan (np.array): longitude of the ascending node [radians]
+        inc (np.array): inclination [radians]
+        plx (np.array): parallax [mas]
+        mtot (np.array): total mass [Solar masses]. Note that this is
         mass (float): mass of this body [Solar masses]. For planets mass ~ 0
 
     Return:
-        raoff (np.array): array of RA offsets between the bodies (origin is at the other body)
-        deoff (np.array): array of Dec offsets between the bodies
-        vz (np.array): array of radial velocity offset between the bodies
+        raoff (np.array): 2-D array (n_orbs x n_dates) of RA offsets between the bodies (origin is at the other body)
+        deoff (np.array): 2-D array (n_orbs x n_dates) of Dec offsets between the bodies
+        vz (np.array): 2-D array (n_orbs x n_dates) of radial velocity offset between the bodies
     """
 
-    ndates = np.size(epochs)
+    n_orbs  = np.size(sma)  # num sets of input orbital parameters
+    n_dates = np.size(epochs) # number of dates to compute offsets and vz
 
-    # Compute period from Kepler's third law
+    # Compute period (from Kepler's third law) and mean motion
     period = np.sqrt(4*np.pi**2.0*(sma*u.AU)**3/(consts.G*(mtot*u.Msun)))
     period = period.to(u.day).value
-
-    # compute mean anomaly
     mean_motion = 2*np.pi/(period) # in rad/day
-    manom = mean_motion*epochs - 2*np.pi*tau
 
-    # compute eccentric anomalies
-    eanom = _calc_ecc_anom(manom, ecc)
+    # compute mean anomaly (size: n_orbs x n_dates)
+    manom = np.zeros((n_orbs,n_dates))
+    for jj in range(0,n_dates):
+        manom[:,jj] = mean_motion*epochs[jj] - 2*np.pi*tau
 
-    # compute the true anomalies
-    tanom = 2.*np.arctan(np.sqrt( (1.0 + ecc)/(1.0 - ecc))*np.tan(0.5*eanom) )
-    theta = tanom + argp
-    radius = sma * (1.0 - ecc * np.cos(eanom))
+    # compute eccentric anomalies (size: n_orbs x n_dates)
+    eanom = np.zeros((n_orbs,n_dates))
+    if n_orbs > 1:
+        for ii in range(0,n_orbs):
+            eanom[ii,:] = _calc_ecc_anom(manom[ii,:], ecc[ii])
+    else:
+        eanom[0,:] = _calc_ecc_anom(manom[0,:], ecc)
 
-    # math from James Graham to now get to delta RA/Dec. Lots of trig
+    # compute the true anomalies (size: n_orbs x n_dates)
+    tanom = np.zeros((n_orbs,n_dates))
+    for jj in range(0,n_dates):
+        tanom[:,jj] = 2.*np.arctan(np.sqrt( (1.0 + ecc)/(1.0 - ecc))*np.tan(0.5*eanom[:,jj]) )
+    # compute 3-D orbital radius of second body (size: n_orbs x n_dates)
+    radius = np.zeros((n_orbs,n_dates))
+    for jj in range(0,n_dates):
+        radius[:,jj] = sma * (1.0 - ecc * np.cos(eanom[:,jj]))
+
+    # compute ra/dec offsets (size: n_orbs x n_dates)
+    raoff = np.zeros((n_orbs,n_dates))
+    deoff = np.zeros((n_orbs,n_dates))
+    # math from James Graham. Lots of trig
     c2i2 = np.cos(0.5*inc)**2
     s2i2 = np.sin(0.5*inc)**2
+    for jj in range(0,n_dates):
+        arg0 = tanom[:,jj] + lan
+        arg1 = tanom[:,jj] + argp + lan
+        arg2 = tanom[:,jj] + argp - lan
+        arg3 = tanom[:,jj] - lan
 
-    arg0 = tanom + lan
-    arg1 = tanom + argp + lan
-    arg2 = tanom + argp - lan
-    arg3 = tanom - lan
+        c1 = np.cos(arg1)
+        c2 = np.cos(arg2)
+        s1 = np.sin(arg1)
+        s2 = np.sin(arg2)
+        sa0 = np.sin(arg0)
+        sa3 = np.sin(arg3)
 
-    c1 = np.cos(arg1)
-    c2 = np.cos(arg2)
-    s1 = np.sin(arg1)
-    s2 = np.sin(arg2)
+        # updated sign convention for Green Eq. 19.4-19.7
+        # return values in arcsecons
+        plx_as = plx * 1e-3
 
-    sa0 = np.sin(arg0)
-    sa3 = np.sin(arg3)
+        raoff[:,jj] = radius[:,jj] * (c2i2*s1 - s2i2*s2) * plx_as
+        deoff[:,jj] = radius[:,jj] * (c2i2*c1 + s2i2*c2) * plx_as
 
-    # updated sign convention for Green Eq. 19.4-19.7
-    # return values in arcsecons
-    plx_as = plx * 1e-3
-
-    raoff = radius * (c2i2*s1 - s2i2*s2) * plx_as
-    deoff = radius * (c2i2*c1 + s2i2*c2) * plx_as
-
-    # compute the RV of the body
-    # first comptue the RV semi-amplitude
+    # compute the radial velocity (vz) of the body (size: n_orbs x n_dates)
+    vz = np.zeros((n_orbs,n_dates))
+    # first comptue the RV semi-amplitude (size: n_orbs)
+    # Treat entries where mass = 0 (test particle) and massive bodies separately
     if mass == 0:
         # basically treating this body as a test particle. we can calcualte a radial velocity for a test particle
         Kv =  mean_motion * (sma * np.sin(inc)) / np.sqrt(1 - ecc**2) * (u.au/u.day)
@@ -84,8 +101,14 @@ def calc_orbit(epochs, sma, ecc, tau, argp, lan, inc, plx, mtot, mass=0):
         m2 = mtot - mass
         Kv = np.sqrt(consts.G / (1.0 - ecc**2)) * (m2 * u.Msun * np.sin(inc)) / np.sqrt(mtot * u.Msun) / np.sqrt(sma * u.au)
         Kv = Kv.to(u.km/u.s)
-    # compute RV
-    vz =  Kv.value * ( ecc*np.cos(argp) + np.cos(argp + tanom) )
+    # compute the vz
+    for jj in range(0,n_dates):
+        vz[:,jj] =  Kv.value * ( ecc*np.cos(argp) + np.cos(argp + tanom[:,jj]) )
+
+    # Squeeze out extra dimension (useful if n_orbs = 1, does nothing if n_orbs > 1)
+    raoff = np.squeeze(raoff)
+    deoff = np.squeeze(deoff)
+    vz = np.squeeze(vz)
 
     return raoff, deoff, vz
 
@@ -134,7 +157,7 @@ def _calc_ecc_anom(manom, ecc, tolerance=1e-9, max_iter=100):
 
 def _mikkola_solver_wrapper(manom, e):
     """
-    Analtyical Mikkola solver (S. Mikkola. 1987. Celestial Mechanics, 40 , 329-334.) for the eccentric anomaly. 
+    Analtyical Mikkola solver (S. Mikkola. 1987. Celestial Mechanics, 40 , 329-334.) for the eccentric anomaly.
     Wrapper for the python implemenation of the IDL version. From Rob De Rosa.
 
     Args:

--- a/tests/test_kepler_solver.py
+++ b/tests/test_kepler_solver.py
@@ -44,7 +44,7 @@ def test_orbit_e03():
     Pretty standard orbit with ecc = 0.3
     """
     # sma, ecc, tau, argp, lan, inc, plx, mtot
-    orbital_params = (10, 0.3, 0.3, 0.5, 1.5, 3, 50, 1.5)
+    orbital_params = np.array([10, 0.3, 0.3, 0.5, 1.5, 3, 50, 1.5])
     epochs = np.array([1000, 1101.4])
     raoffs, deoffs, vzs = kepler.calc_orbit(epochs, orbital_params[0], orbital_params[1], orbital_params[2], orbital_params[3],
                                         orbital_params[4], orbital_params[5], orbital_params[6], orbital_params[7])
@@ -62,14 +62,14 @@ def test_orbit_e03():
 
 def test_orbit_e03_array():
     # sma, ecc, tau, argp, lan, inc, plx, mtot
-    sma = [10,10,10]
-    ecc = [0.3,0.3,0.3]
-    tau = [0.3,0.3,0.3]
-    argp = [0.5,0.5,0.5]
-    lan = [1.5,1.5,1.5]
-    inc = [3,3,3]
-    plx = [50,50,50]
-    mtot = [1.5,1.5,1.5]
+    sma = np.array([10,10,10])
+    ecc = np.array([0.3,0.3,0.3])
+    tau = np.array([0.3,0.3,0.3])
+    argp = np.array([0.5,0.5,0.5])
+    lan = np.array([1.5,1.5,1.5])
+    inc = np.array([3,3,3])
+    plx = np.array([50,50,50])
+    mtot = np.array([1.5,1.5,1.5])
     epochs = np.array([1000, 1101.4])
     raoffs, deoffs, vzs = kepler.calc_orbit(epochs, sma, ecc, tau, argp, lan, inc, plx, mtot)
 
@@ -90,7 +90,7 @@ def test_orbit_e99():
     Test a highly eccentric orbit (ecc=0.99). Again validate against James Graham's orbit code
     """
     # sma, ecc, tau, argp, lan, inc, plx, mtot
-    orbital_params = (10, 0.99, 0.3, 0.5, 1.5, 3, 50, 1.5)
+    orbital_params = np.array([10, 0.99, 0.3, 0.5, 1.5, 3, 50, 1.5])
     epochs = np.array([1000, 1101.4])
     raoffs, deoffs, vzs = kepler.calc_orbit(epochs, orbital_params[0], orbital_params[1], orbital_params[2], orbital_params[3],
                                         orbital_params[4], orbital_params[5], orbital_params[6], orbital_params[7])
@@ -114,7 +114,7 @@ def test_orbit_with_mass():
     same total mass.
     """
     # sma, ecc, tau, argp, lan, inc, plx, mtot
-    orbital_params = (10, 0.99, 0.3, 0.5, 1.5, 3, 50, 1.5)
+    orbital_params = np.array([10, 0.99, 0.3, 0.5, 1.5, 3, 50, 1.5])
     epochs = np.array([1000, 1101.4])
     raoffs, deoffs, vzs = kepler.calc_orbit(epochs, orbital_params[0], orbital_params[1], orbital_params[2], orbital_params[3],
                                         orbital_params[4], orbital_params[5], orbital_params[6], orbital_params[7], mass=orbital_params[7]/2)
@@ -131,9 +131,9 @@ def test_orbit_with_mass():
         assert truth == pytest.approx(meas, abs=threshold)
 
 if __name__ == "__main__":
-    test_analytical_ecc_anom_solver()
-    test_iterative_ecc_anom_solver()
-    test_orbit_e03()
+    #test_analytical_ecc_anom_solver()
+    #test_iterative_ecc_anom_solver()
+    #test_orbit_e03()
     test_orbit_e03_array()
-    test_orbit_e99()
-    test_orbit_with_mass()
+    #test_orbit_e99()
+    #est_orbit_with_mass()

--- a/tests/test_kepler_solver.py
+++ b/tests/test_kepler_solver.py
@@ -61,6 +61,9 @@ def test_orbit_e03():
         assert truth == pytest.approx(meas, abs=threshold)
 
 def test_orbit_e03_array():
+    """
+    Test orbitize.kepler.calc_orbit() with a standard orbit with ecc = 0.3 and an array of keplerian input
+    """
     # sma, ecc, tau, argp, lan, inc, plx, mtot
     sma = np.array([10,10,10])
     ecc = np.array([0.3,0.3,0.3])
@@ -73,16 +76,22 @@ def test_orbit_e03_array():
     epochs = np.array([1000, 1101.4])
     raoffs, deoffs, vzs = kepler.calc_orbit(epochs, sma, ecc, tau, argp, lan, inc, plx, mtot)
 
-    true_raoff = [0.15286786,  0.18039408]
-    true_deoff = [-0.46291038, -0.4420127]
-    true_vz = [0.86448656,  0.97591289]
-
-    # for meas, truth in zip(raoffs, true_raoff):
-    #     assert truth == pytest.approx(meas, abs=threshold)
-    # for meas, truth in zip(deoffs, true_deoff):
-    #     assert truth == pytest.approx(meas, abs=threshold)
-    # for meas, truth in zip(vzs, true_vz):
-    #     assert truth == pytest.approx(meas, abs=threshold)
+    true_raoff = np.array([[ 0.15286786,  0.18039408],
+                           [ 0.15286786,  0.18039408],
+                           [ 0.15286786,  0.18039408]])
+    true_deoff = np.array([[-0.46291038, -0.4420127],
+                           [-0.46291038, -0.4420127],
+                           [-0.46291038, -0.4420127]])
+    true_vz    = np.array([[0.86448656,  0.97591289],
+                           [0.86448656,  0.97591289],
+                           [0.86448656,  0.97591289]])
+    for ii in range(0,3):
+        for meas, truth in zip(raoffs[ii,:], true_raoff[ii,:]):
+            assert truth == pytest.approx(meas, abs=threshold)
+        for meas, truth in zip(deoffs[ii,:], true_deoff[ii,:]):
+            assert truth == pytest.approx(meas, abs=threshold)
+        for meas, truth in zip(vzs[ii,:], true_vz[ii,:]):
+            assert truth == pytest.approx(meas, abs=threshold)
 
 
 def test_orbit_e99():
@@ -130,10 +139,44 @@ def test_orbit_with_mass():
     for meas, truth in zip(vzs, true_vz):
         assert truth == pytest.approx(meas, abs=threshold)
 
+def test_orbit_with_mass_array():
+    """
+    Test orbitize.kepler.calc_orbit() with massive particle on a standard orbit with ecc = 0.3 and an array of keplerian input
+    """
+    # sma, ecc, tau, argp, lan, inc, plx, mtot
+    sma = np.array([10,10,10])
+    ecc = np.array([0.3,0.3,0.3])
+    tau = np.array([0.3,0.3,0.3])
+    argp = np.array([0.5,0.5,0.5])
+    lan = np.array([1.5,1.5,1.5])
+    inc = np.array([3,3,3])
+    plx = np.array([50,50,50])
+    mtot = np.array([1.5,1.5,1.5])
+    epochs = np.array([1000, 1101.4])
+    raoffs, deoffs, vzs = kepler.calc_orbit(epochs, sma, ecc, tau, argp, lan, inc, plx, mtot, mtot[0]/2)
+
+    true_raoff = np.array([[ 0.15286786,  0.18039408],
+                           [ 0.15286786,  0.18039408],
+                           [ 0.15286786,  0.18039408]])
+    true_deoff = np.array([[-0.46291038, -0.4420127],
+                           [-0.46291038, -0.4420127],
+                           [-0.46291038, -0.4420127]])
+    true_vz    = np.array([[0.86448656/2,  0.97591289/2],
+                           [0.86448656/2,  0.97591289/2],
+                           [0.86448656/2,  0.97591289/2]])
+    for ii in range(0,3):
+        for meas, truth in zip(raoffs[ii,:], true_raoff[ii,:]):
+            assert truth == pytest.approx(meas, abs=threshold)
+        for meas, truth in zip(deoffs[ii,:], true_deoff[ii,:]):
+            assert truth == pytest.approx(meas, abs=threshold)
+        for meas, truth in zip(vzs[ii,:], true_vz[ii,:]):
+            assert truth == pytest.approx(meas, abs=threshold)
+
 if __name__ == "__main__":
-    #test_analytical_ecc_anom_solver()
-    #test_iterative_ecc_anom_solver()
-    #test_orbit_e03()
+    test_analytical_ecc_anom_solver()
+    test_iterative_ecc_anom_solver()
+    test_orbit_e03()
     test_orbit_e03_array()
-    #test_orbit_e99()
-    #est_orbit_with_mass()
+    test_orbit_e99()
+    test_orbit_with_mass()
+    test_orbit_with_mass_array()

--- a/tests/test_kepler_solver.py
+++ b/tests/test_kepler_solver.py
@@ -60,6 +60,30 @@ def test_orbit_e03():
     for meas, truth in zip(vzs, true_vz):
         assert truth == pytest.approx(meas, abs=threshold)
 
+def test_orbit_e03_array():
+    # sma, ecc, tau, argp, lan, inc, plx, mtot
+    sma = [10,10,10]
+    ecc = [0.3,0.3,0.3]
+    tau = [0.3,0.3,0.3]
+    argp = [0.5,0.5,0.5]
+    lan = [1.5,1.5,1.5]
+    inc = [3,3,3]
+    plx = [50,50,50]
+    mtot = [1.5,1.5,1.5]
+    epochs = np.array([1000, 1101.4])
+    raoffs, deoffs, vzs = kepler.calc_orbit(epochs, sma, ecc, tau, argp, lan, inc, plx, mtot)
+
+    true_raoff = [0.15286786,  0.18039408]
+    true_deoff = [-0.46291038, -0.4420127]
+    true_vz = [0.86448656,  0.97591289]
+
+    # for meas, truth in zip(raoffs, true_raoff):
+    #     assert truth == pytest.approx(meas, abs=threshold)
+    # for meas, truth in zip(deoffs, true_deoff):
+    #     assert truth == pytest.approx(meas, abs=threshold)
+    # for meas, truth in zip(vzs, true_vz):
+    #     assert truth == pytest.approx(meas, abs=threshold)
+
 
 def test_orbit_e99():
     """
@@ -110,5 +134,6 @@ if __name__ == "__main__":
     test_analytical_ecc_anom_solver()
     test_iterative_ecc_anom_solver()
     test_orbit_e03()
+    test_orbit_e03_array()
     test_orbit_e99()
     test_orbit_with_mass()


### PR DESCRIPTION
This upgrade addresses issue #16 and allows kepler.py's calc_orbit to handle arrays as well as scalars as input for orbital elements so that we solve many orbits simultaneously.

Note that calc_orbit takes in epochs which has size n_dates and orbital elements which has size n_orbs. For most cases, n_dates << n_orbs so almost all of the loops in calc_orbit is a loop through the epochs. The exception is the eccentric anomaly solver, which can only solve for one eccentricity at a time, so it is a loop through each set of orbital elements. Something to keep in mind if we need further speedups.

So far, a speed test with 100,000 simultaneous orbits on this branch takes 3.7 seconds. Running the old version (scalars for orbital elements) 100,000 times takes about 90 seconds.