### PR TITLE
Eanom optimizations

### DIFF
--- a/orbitize/kepler.py
+++ b/orbitize/kepler.py
@@ -122,6 +122,7 @@ def _calc_ecc_anom(manom, ecc, tolerance=1e-9, max_iter=100):
     """
 
     eanom = np.full(np.shape(manom), np.nan)
+    ecc = np.array(ecc)
 
     # First deal with e == 0 elements
     ind_zero = np.where(ecc == 0.0)

--- a/orbitize/kepler.py
+++ b/orbitize/kepler.py
@@ -120,32 +120,20 @@ def _calc_ecc_anom(manom, ecc, tolerance=1e-9, max_iter=100):
     Written: Jason Wang, 2018
     """
 
-    if hasattr(ecc, '__len__'):
-        # Initialize to nans
-        eanom = np.full(np.shape(manom), np.nan)
+    eanom = np.full(np.shape(manom), np.nan)
 
-        # First deal with e == 0 elements
-        ind_zero = np.where(ecc == 0.0)
-        eanom[ind_zero] = manom[ind_zero]
+    # First deal with e == 0 elements
+    ind_zero = np.where(ecc == 0.0)
+    if len(ind_zero[0]) > 0: eanom[ind_zero] = manom[ind_zero]
 
-        # Now low eccentricities
-        ind_low = np.where(ecc < 0.95)
-        if len(ind_low[0]) > 0:
-            eanom[ind_low] = _newton_solver(manom[ind_low], ecc[ind_low], tolerance=tolerance, max_iter=max_iter)
+    # Now low eccentricities
+    ind_low = np.where(ecc < 0.95)
+    if len(ind_low[0]) > 0: eanom[ind_low] = _newton_solver(manom[ind_low], ecc[ind_low], tolerance=tolerance, max_iter=max_iter)
 
-        # Now high eccentricities
-        ind_high = np.where(ecc >= 0.95)
-        if len(ind_high[0]) > 0:
-            eanom[ind_high] = _mikkola_solver_wrapper(manom[ind_high], ecc[ind_high])
+    # Now high eccentricities
+    ind_high = np.where(ecc >= 0.95)
+    if len(ind_high[0]) > 0: eanom[ind_high] = _mikkola_solver_wrapper(manom[ind_high], ecc[ind_high])
 
-    else:
-        if ecc == 0.0:
-            eanom = np.copy(manom)
-        else:
-            if ecc < 0.95:
-                eanom = _newton_solver(manom, ecc, tolerance=tolerance, max_iter=max_iter)
-            else:
-                eanom = _mikkola_solver_wrapper(manom, ecc) 
 
     return eanom
 

--- a/orbitize/kepler.py
+++ b/orbitize/kepler.py
@@ -136,16 +136,20 @@ def _calc_ecc_anom(manom, ecc, tolerance=1e-9, max_iter=100):
     # Initialize eanom array
     eanom = np.full(np.shape(manom), np.nan)
 
-    # First deal with e == 0 elements
-    ind_zero = np.where(ecc == 0.0)
+    # Save some boolean arrays
+    ecc_zero = ecc == 0.0
+    ecc_low = ecc < 0.95
+
+    # First deal with e == 0 elements    
+    ind_zero = np.where(ecc_zero)
     if len(ind_zero[0]) > 0: eanom[ind_zero] = manom[ind_zero]
 
     # Now low eccentricities
-    ind_low = np.where(ecc < 0.95)
+    ind_low = np.where(~ecc_zero & ecc_low)
     if len(ind_low[0]) > 0: eanom[ind_low] = _newton_solver(manom[ind_low], ecc[ind_low], tolerance=tolerance, max_iter=max_iter)
 
     # Now high eccentricities
-    ind_high = np.where(ecc >= 0.95)
+    ind_high = np.where(~ecc_zero & ~ecc_low)
     if len(ind_high[0]) > 0: eanom[ind_high] = _mikkola_solver_wrapper(manom[ind_high], ecc[ind_high])
 
     return np.squeeze(eanom)[()]

--- a/orbitize/kepler.py
+++ b/orbitize/kepler.py
@@ -87,8 +87,8 @@ def calc_orbit(epochs, sma, ecc, tau, argp, lan, inc, plx, mtot, mass=None):
 
     # compute the radial velocity (vz) of the body (size: n_orbs x n_dates)
     # first comptue the RV semi-amplitude (size: n_orbs x n_dates)
-    m2 = mtot - mass
-    Kv = np.sqrt(consts.G / (1.0 - ecc**2)) * (m2 * u.Msun * np.sin(inc)) / np.sqrt(mtot * u.Msun) / np.sqrt(sma * u.au)
+    m1 = mtot - mass # mass of the primary star
+    Kv = np.sqrt(consts.G / (1.0 - ecc**2)) * (m1 * u.Msun * np.sin(inc)) / np.sqrt(mtot * u.Msun) / np.sqrt(sma * u.au)
     # Convert to km/s
     Kv = Kv.to(u.km/u.s)
     # compute the vz

--- a/orbitize/kepler.py
+++ b/orbitize/kepler.py
@@ -110,7 +110,7 @@ def _calc_ecc_anom(manom, ecc, tolerance=1e-9, max_iter=100):
     Code from Rob De Rosa's orbit solver (e < 0.95 use Newton, e >= 0.95 use Mikkola)
 
     Args:
-        manom (float/np.array): mean anomaly, either a scalar or np.array or any shape
+        manom (float/np.array): mean anomaly, either a scalar or np.array of any shape
         ecc (float/np.array): eccentricity, either a scalar or np.array of the same shape as manom
         tolerance (float, optional): absolute tolerance of iterative computation. Defaults to 1e-9.
         max_iter (int, optional): maximum number of iterations before switching. Defaults to 100.

--- a/orbitize/kepler.py
+++ b/orbitize/kepler.py
@@ -86,18 +86,13 @@ def calc_orbit(epochs, sma, ecc, tau, argp, lan, inc, plx, mtot, mass=None):
     deoff = radius * (c2i2*c1 + s2i2*c2) * plx_as
 
     # compute the radial velocity (vz) of the body (size: n_orbs x n_dates)
-    # first comptue the RV semi-amplitude (size: n_orbs)
-    # Treat entries where mass = 0 (test particle) and massive bodies separately
-    Kv = np.zeros((n_orbs,n_dates))
-    # Find indices of massless cases (mass==0)
-    m0_ind = mass==0
-    # Calculate radial velocity where mass is zero (test particle)
-    Kv[m0_ind] = (mean_motion[m0_ind] * (sma[m0_ind] * np.sin(inc[m0_ind])) / np.sqrt(1 - ecc[m0_ind]**2) * (u.au/u.day)).to(u.km/u.s)
-    # Calculate radial velocity when mass is non-zero
+    # first comptue the RV semi-amplitude (size: n_orbs x n_dates)
     m2 = mtot - mass
-    Kv[~m0_ind] = (np.sqrt(consts.G / (1.0 - ecc[~m0_ind]**2)) * (m2[~m0_ind] * u.Msun * np.sin(inc[~m0_ind])) / np.sqrt(mtot[~m0_ind] * u.Msun) / np.sqrt(sma[~m0_ind] * u.au)).to(u.km/u.s)
+    Kv = np.sqrt(consts.G / (1.0 - ecc**2)) * (m2 * u.Msun * np.sin(inc)) / np.sqrt(mtot * u.Msun) / np.sqrt(sma * u.au)
+    # Convert to km/s
+    Kv = Kv.to(u.km/u.s)
     # compute the vz
-    vz =  Kv * ( ecc*np.cos(argp) + np.cos(argp + tanom) )
+    vz =  Kv.value * ( ecc*np.cos(argp) + np.cos(argp + tanom) )
 
     # Squeeze out extra dimension (useful if n_orbs = 1, does nothing if n_orbs > 1)
     # [()] used to convert 1-element arrays into scalars, has no effect for larger arrays

--- a/orbitize/kepler.py
+++ b/orbitize/kepler.py
@@ -22,8 +22,8 @@ def calc_orbit(epochs, sma, ecc, tau, argp, lan, inc, plx, mtot, mass=0):
         lan (np.array): longitude of the ascending node [radians]
         inc (np.array): inclination [radians]
         plx (np.array): parallax [mas]
-        mtot (np.array): total mass [Solar masses]. Note that this is
-        mass (float): mass of this body [Solar masses]. For planets mass ~ 0
+        mtot (np.array): total mass [Solar masses]
+        mass (np.array): mass of the body [Solar masses]. For planets mass ~ 0 (default)
 
     Return:
         raoff (np.array): 2-D array (n_orbs x n_dates) of RA offsets between the bodies (origin is at the other body)

--- a/orbitize/kepler.py
+++ b/orbitize/kepler.py
@@ -36,61 +36,52 @@ def calc_orbit(epochs, sma, ecc, tau, argp, lan, inc, plx, mtot, mass=0):
     n_orbs  = np.size(sma)  # num sets of input orbital parameters
     n_dates = np.size(epochs) # number of dates to compute offsets and vz
 
+    sma = np.transpose(np.tile(sma, (n_dates, 1)))
+    inc = np.transpose(np.tile(inc, (n_dates, 1)))
+    ecc = np.transpose(np.tile(ecc, (n_dates, 1)))
+    argp = np.transpose(np.tile(argp, (n_dates, 1)))
+    lan = np.transpose(np.tile(lan, (n_dates, 1)))
+    tau = np.transpose(np.tile(tau, (n_dates, 1)))
+    plx = np.transpose(np.tile(plx, (n_dates, 1)))
+    mtot = np.transpose(np.tile(mtot, (n_dates, 1)))
+    epochs = np.tile(epochs, (n_orbs, 1))
+
     # Compute period (from Kepler's third law) and mean motion
     period = np.sqrt(4*np.pi**2.0*(sma*u.AU)**3/(consts.G*(mtot*u.Msun)))
     period = period.to(u.day).value
     mean_motion = 2*np.pi/(period) # in rad/day
 
     # compute mean anomaly (size: n_orbs x n_dates)
-    manom = np.zeros((n_orbs,n_dates))
-    for jj in range(0,n_dates):
-        manom[:,jj] = mean_motion*epochs[jj] - 2*np.pi*tau
+    manom = (mean_motion*epochs - 2*np.pi*tau) #% 2*np.pi
 
     # compute eccentric anomalies (size: n_orbs x n_dates)
-    eanom = np.zeros((n_orbs,n_dates))
-    if n_orbs > 1:
-        for ii in range(0,n_orbs):
-            eanom[ii,:] = _calc_ecc_anom(manom[ii,:], ecc[ii])
-    else:
-        eanom[0,:] = _calc_ecc_anom(manom[0,:], ecc)
-
+    eanom = _calc_ecc_anom(manom, ecc)
+    
     # compute the true anomalies (size: n_orbs x n_dates)
-    tanom = np.zeros((n_orbs,n_dates))
-    for jj in range(0,n_dates):
-        tanom[:,jj] = 2.*np.arctan(np.sqrt( (1.0 + ecc)/(1.0 - ecc))*np.tan(0.5*eanom[:,jj]) )
+    tanom = 2.*np.arctan(np.sqrt( (1.0 + ecc)/(1.0 - ecc))*np.tan(0.5*eanom) )
+
     # compute 3-D orbital radius of second body (size: n_orbs x n_dates)
-    radius = np.zeros((n_orbs,n_dates))
-    for jj in range(0,n_dates):
-        radius[:,jj] = sma * (1.0 - ecc * np.cos(eanom[:,jj]))
+    radius = sma * (1.0 - ecc * np.cos(eanom))
 
     # compute ra/dec offsets (size: n_orbs x n_dates)
-    raoff = np.zeros((n_orbs,n_dates))
-    deoff = np.zeros((n_orbs,n_dates))
     # math from James Graham. Lots of trig
     c2i2 = np.cos(0.5*inc)**2
     s2i2 = np.sin(0.5*inc)**2
-    for jj in range(0,n_dates):
-        arg0 = tanom[:,jj] + lan
-        arg1 = tanom[:,jj] + argp + lan
-        arg2 = tanom[:,jj] + argp - lan
-        arg3 = tanom[:,jj] - lan
+    arg1 = tanom + argp + lan
+    arg2 = tanom + argp - lan
+    c1 = np.cos(arg1)
+    c2 = np.cos(arg2)
+    s1 = np.sin(arg1)
+    s2 = np.sin(arg2)
 
-        c1 = np.cos(arg1)
-        c2 = np.cos(arg2)
-        s1 = np.sin(arg1)
-        s2 = np.sin(arg2)
-        sa0 = np.sin(arg0)
-        sa3 = np.sin(arg3)
+    # updated sign convention for Green Eq. 19.4-19.7
+    # return values in arcsecons
+    plx_as = plx * 1e-3
 
-        # updated sign convention for Green Eq. 19.4-19.7
-        # return values in arcsecons
-        plx_as = plx * 1e-3
-
-        raoff[:,jj] = radius[:,jj] * (c2i2*s1 - s2i2*s2) * plx_as
-        deoff[:,jj] = radius[:,jj] * (c2i2*c1 + s2i2*c2) * plx_as
+    raoff = radius * (c2i2*s1 - s2i2*s2) * plx_as
+    deoff = radius * (c2i2*c1 + s2i2*c2) * plx_as
 
     # compute the radial velocity (vz) of the body (size: n_orbs x n_dates)
-    vz = np.zeros((n_orbs,n_dates))
     # first comptue the RV semi-amplitude (size: n_orbs)
     # Treat entries where mass = 0 (test particle) and massive bodies separately
     if mass == 0:
@@ -104,8 +95,7 @@ def calc_orbit(epochs, sma, ecc, tau, argp, lan, inc, plx, mtot, mass=0):
         Kv = np.sqrt(consts.G / (1.0 - ecc**2)) * (m2 * u.Msun * np.sin(inc)) / np.sqrt(mtot * u.Msun) / np.sqrt(sma * u.au)
         Kv = Kv.to(u.km/u.s)
     # compute the vz
-    for jj in range(0,n_dates):
-        vz[:,jj] =  Kv.value * ( ecc*np.cos(argp) + np.cos(argp + tanom[:,jj]) )
+    vz =  Kv.value * ( ecc*np.cos(argp) + np.cos(argp + tanom) )
 
     # Squeeze out extra dimension (useful if n_orbs = 1, does nothing if n_orbs > 1)
     raoff = np.squeeze(raoff)
@@ -113,7 +103,6 @@ def calc_orbit(epochs, sma, ecc, tau, argp, lan, inc, plx, mtot, mass=0):
     vz = np.squeeze(vz)
 
     return raoff, deoff, vz
-
 
 def _calc_ecc_anom(manom, ecc, tolerance=1e-9, max_iter=100):
     """
@@ -131,35 +120,72 @@ def _calc_ecc_anom(manom, ecc, tolerance=1e-9, max_iter=100):
     Written: Jason Wang, 2018
     """
 
-    if ecc == 0.0:
-        eanom = np.copy(manom)
+    if hasattr(ecc, '__len__'):
+        # Initialize to nans
+        eanom = np.full(np.shape(manom), np.nan)
+
+        # First deal with e == 0 elements
+        ind_zero = np.where(ecc == 0.0)
+        eanom[ind_zero] = manom[ind_zero]
+
+        # Now low eccentricities
+        ind_low = np.where(ecc < 0.95)
+        if len(ind_low[0]) > 0:
+            eanom[ind_low] = _newton_solver(manom[ind_low], ecc[ind_low], tolerance=tolerance, max_iter=max_iter)
+
+        # Now high eccentricities
+        ind_high = np.where(ecc >= 0.95)
+        if len(ind_high[0]) > 0:
+            eanom[ind_high] = _mikkola_solver_wrapper(manom[ind_high], ecc[ind_high])
+
     else:
-        if ecc < 0.95:
+        if ecc == 0.0:
             eanom = np.copy(manom)
-
-            #Let's do two iterations to start with
-            eanom -= (eanom - (ecc * np.sin(eanom)) - manom) / (1.0 - (ecc * np.cos(eanom)))
-            eanom -= (eanom - (ecc * np.sin(eanom)) - manom) / (1.0 - (ecc * np.cos(eanom)))
-
-            diff = (eanom - (ecc * np.sin(eanom)) - manom) / (1.0 - (ecc * np.cos(eanom)))
-            abs_diff = np.abs(diff)
-            ind = np.where(abs_diff > tolerance)
-            niter = 0
-            while ((ind[0].size > 0) and (niter <= max_iter)):
-                eanom[ind] -= diff[ind]
-                diff[ind] = (eanom[ind] - (ecc * np.sin(eanom[ind])) - manom[ind]) / (1.0 - (ecc * np.cos(eanom[ind])))
-                abs_diff[ind] = np.abs(diff[ind])
-                ind = np.where(abs_diff > tolerance)
-                niter += 1
-            if niter >= max_iter:
-                print(manom[ind], eanom[ind], ecc, '> {} iter.'.format(max_iter))
-                eanom = _mikkola_solver_wrapper(manom, ecc)
         else:
-            eanom = _mikkola_solver_wrapper(manom, ecc) # Send it to the analytical version, this has not happened yet...
+            if ecc < 0.95:
+                eanom = _newton_solver(manom, ecc, tolerance=tolerance, max_iter=max_iter)
+            else:
+                eanom = _mikkola_solver_wrapper(manom, ecc) 
 
     return eanom
 
-def _mikkola_solver_wrapper(manom, e):
+def _newton_solver(manom, ecc, tolerance=1e-9, max_iter=100):
+    """
+    Newton-Raphson solver for eccentric anomaly.
+    Args:
+        manom (np.array): array of mean anomalies
+        ecc (np.array): array of eccentricities
+    Return:
+        eanom (np.array): array of eccentric anomalies
+    
+    Written: Rob De Rosa, 2018
+
+    """
+
+    # Initialize at E = M. Probably could have a better choice of starting position
+    eanom = np.copy(manom)
+
+    # Let's do two iterations to start with
+    eanom -= (eanom - (ecc * np.sin(eanom)) - manom) / (1.0 - (ecc * np.cos(eanom)))
+    eanom -= (eanom - (ecc * np.sin(eanom)) - manom) / (1.0 - (ecc * np.cos(eanom)))
+
+    diff = (eanom - (ecc * np.sin(eanom)) - manom) / (1.0 - (ecc * np.cos(eanom)))
+    abs_diff = np.abs(diff)
+    ind = np.where(abs_diff > tolerance)
+    niter = 0
+    while ((ind[0].size > 0) and (niter <= max_iter)):
+        eanom[ind] -= diff[ind]
+        diff[ind] = (eanom[ind] - (ecc[ind] * np.sin(eanom[ind])) - manom[ind]) / (1.0 - (ecc[ind] * np.cos(eanom[ind])))
+        abs_diff[ind] = np.abs(diff[ind])
+        ind = np.where(abs_diff > tolerance)
+        niter += 1
+    if niter >= max_iter:
+        print(manom[ind], eanom[ind], ecc[ind], '> {} iter.'.format(max_iter))
+        eanom[ind] = _mikkola_solver_wrapper(manom[ind], ecc[ind]) # Send remaining orbits to the analytical version, this has not happened yet...
+
+    return eanom
+
+def _mikkola_solver_wrapper(manom, ecc):
     """
     Analtyical Mikkola solver (S. Mikkola. 1987. Celestial Mechanics, 40 , 329-334.) for the eccentric anomaly.
     Wrapper for the python implemenation of the IDL version. From Rob De Rosa.
@@ -168,18 +194,18 @@ def _mikkola_solver_wrapper(manom, e):
         manom (np.array): array of mean anomalies
         ecc (float): eccentricity
     Return:
-        eccanom (np.array): array of eccentric anomalies
+        eanom (np.array): array of eccentric anomalies
 
     Written: Jason Wang, 2018
     """
     ind_change = np.where(manom > np.pi)
     manom[ind_change] = (2.0 * np.pi) - manom[ind_change]
-    Eanom = _mikkola_solver(manom, e)
-    Eanom[ind_change] = (2.0 * np.pi) - Eanom[ind_change]
+    eanom = _mikkola_solver(manom, ecc)
+    eanom[ind_change] = (2.0 * np.pi) - eanom[ind_change]
 
-    return Eanom
+    return eanom
 
-def _mikkola_solver(manom, e):
+def _mikkola_solver(manom, ecc):
     """
     Analtyical Mikkola solver for the eccentric anomaly.
     Adapted from IDL routine keplereq.pro by Rob De Rosa http://www.lpl.arizona.edu/~bjackson/idl_code/keplereq.pro
@@ -188,33 +214,33 @@ def _mikkola_solver(manom, e):
         manom (np.array): array of mean anomalies
         ecc (float): eccentricity
     Return:
-        eccanom (np.array): array of eccentric anomalies
+        eanom (np.array): array of eccentric anomalies
 
     Written: Jason Wang, 2018
     """
 
-    alpha = (1.0 - e) / ((4.0 * e) + 0.5)
-    beta = (0.5 * manom) / ((4.0 * e) + 0.5)
+    alpha = (1.0 - ecc) / ((4.0 * ecc) + 0.5)
+    beta = (0.5 * manom) / ((4.0 * ecc) + 0.5)
 
     aux = np.sqrt(beta**2.0 + alpha**3.0)
     z = beta + aux
     z = z**(1.0/3.0)
 
     s0 = z - (alpha/z)
-    s1 = s0 - (0.078*(s0**5.0)) / (1.0 + e)
-    e0 = manom + (e * (3.0*s1 - 4.0*(s1**3.0)))
+    s1 = s0 - (0.078*(s0**5.0)) / (1.0 + ecc)
+    e0 = manom + (ecc * (3.0*s1 - 4.0*(s1**3.0)))
 
     se0=np.sin(e0)
     ce0=np.cos(e0)
 
-    f  = e0-e*se0-manom
-    f1 = 1.0-e*ce0
-    f2 = e*se0
-    f3 = e*ce0
+    f  = e0-ecc*se0-manom
+    f1 = 1.0-ecc*ce0
+    f2 = ecc*se0
+    f3 = ecc*ce0
     f4 = -f2
     u1 = -f/f1
     u2 = -f/(f1+0.5*f2*u1)
-    u3 = -f/(f1+0.5*f2*u2+0.16666666666667*f3*u2*u2)
-    u4 = -f/(f1+0.5*f2*u3+0.16666666666667*f3*u3*u3+0.041666666666667*f4*(u3**3.0))
+    u3 = -f/(f1+0.5*f2*u2+(1.0/6.0)*f3*u2*u2)
+    u4 = -f/(f1+0.5*f2*u3+(1.0/6.0)*f3*u3*u3+(1.0/24.0)*f4*(u3**3.0))
 
     return (e0 + u4)

--- a/orbitize/kepler.py
+++ b/orbitize/kepler.py
@@ -161,9 +161,9 @@ def _newton_solver(manom, ecc, tolerance=1e-9, max_iter=100, eanom0=None):
 
     """
 
-    # Initialize at E=0, E=pi is better at very high eccentricities
+    # Initialize at E=M, E=pi is better at very high eccentricities
     if eanom0 is None:
-        eanom = np.full(np.shape(manom), 0.0)
+        eanom = np.full(np.shape(manom), M)
     else:
         eanom = np.copy(eanom0)
 

--- a/orbitize/kepler.py
+++ b/orbitize/kepler.py
@@ -110,8 +110,8 @@ def _calc_ecc_anom(manom, ecc, tolerance=1e-9, max_iter=100):
     Code from Rob De Rosa's orbit solver (e < 0.95 use Newton, e >= 0.95 use Mikkola)
 
     Args:
-        manom (np.array): array of mean anomalies
-        ecc (float): eccentricity
+        manom (np.array): array of mean anomalies, shape (n_orbs) or (n_orbs, n_dates)
+        ecc (float/np.array): eccentricity, either a scalar or shape (n_orbs, n_dates)
         tolerance (float, optional): absolute tolerance of iterative computation. Defaults to 1e-9.
         max_iter (int, optional): maximum number of iterations before switching. Defaults to 100.
     Return:
@@ -120,8 +120,11 @@ def _calc_ecc_anom(manom, ecc, tolerance=1e-9, max_iter=100):
     Written: Jason Wang, 2018
     """
 
+    # If ecc is a scalar, make it the same shape as manom
+    if np.isscalar(ecc):
+        ecc = np.full(np.shape(manom), ecc)
+
     eanom = np.full(np.shape(manom), np.nan)
-    if np.isscalar(ecc): ecc = np.reshape(ecc, (1, ))
 
     # First deal with e == 0 elements
     ind_zero = np.where(ecc == 0.0)
@@ -190,7 +193,7 @@ def _mikkola_solver_wrapper(manom, ecc):
     manom[ind_change] = (2.0 * np.pi) - manom[ind_change]
     eanom = _mikkola_solver(manom, ecc)
     eanom[ind_change] = (2.0 * np.pi) - eanom[ind_change]
-
+    
     return eanom
 
 def _mikkola_solver(manom, ecc):

--- a/orbitize/kepler.py
+++ b/orbitize/kepler.py
@@ -122,7 +122,7 @@ def _calc_ecc_anom(manom, ecc, tolerance=1e-9, max_iter=100):
     """
 
     eanom = np.full(np.shape(manom), np.nan)
-    ecc = np.array(ecc)
+    if np.isscalar(ecc): ecc = np.reshape(ecc, (1, ))
 
     # First deal with e == 0 elements
     ind_zero = np.where(ecc == 0.0)
@@ -135,7 +135,6 @@ def _calc_ecc_anom(manom, ecc, tolerance=1e-9, max_iter=100):
     # Now high eccentricities
     ind_high = np.where(ecc >= 0.95)
     if len(ind_high[0]) > 0: eanom[ind_high] = _mikkola_solver_wrapper(manom[ind_high], ecc[ind_high])
-
 
     return eanom
 

--- a/orbitize/kepler.py
+++ b/orbitize/kepler.py
@@ -4,7 +4,6 @@ This module solves for the orbit of the planet given Keplerian parameters
 import numpy as np
 import astropy.units as u
 import astropy.constants as consts
-from astropy.io import fits
 
 
 def calc_orbit(epochs, sma, ecc, tau, argp, lan, inc, plx, mtot, mass=0):

--- a/orbitize/kepler.py
+++ b/orbitize/kepler.py
@@ -98,9 +98,10 @@ def calc_orbit(epochs, sma, ecc, tau, argp, lan, inc, plx, mtot, mass=0):
     vz =  Kv.value * ( ecc*np.cos(argp) + np.cos(argp + tanom) )
 
     # Squeeze out extra dimension (useful if n_orbs = 1, does nothing if n_orbs > 1)
-    raoff = np.squeeze(raoff)
-    deoff = np.squeeze(deoff)
-    vz = np.squeeze(vz)
+    # [()] used to convert 1-element arrays into scalars, has no effect for larger arrays
+    raoff = np.squeeze(raoff)[()]
+    deoff = np.squeeze(deoff)[()]
+    vz = np.squeeze(vz)[()]
 
     return raoff, deoff, vz
 

--- a/orbitize/kepler.py
+++ b/orbitize/kepler.py
@@ -163,7 +163,7 @@ def _newton_solver(manom, ecc, tolerance=1e-9, max_iter=100, eanom0=None):
 
     # Initialize at E=M, E=pi is better at very high eccentricities
     if eanom0 is None:
-        eanom = np.full(np.shape(manom), M)
+        eanom = np.copy(manom)
     else:
         eanom = np.copy(eanom0)
 

--- a/orbitize/kepler.py
+++ b/orbitize/kepler.py
@@ -4,6 +4,7 @@ This module solves for the orbit of the planet given Keplerian parameters
 import numpy as np
 import astropy.units as u
 import astropy.constants as consts
+from astropy.io import fits
 
 
 def calc_orbit(epochs, sma, ecc, tau, argp, lan, inc, plx, mtot, mass=0):
@@ -52,8 +53,8 @@ def calc_orbit(epochs, sma, ecc, tau, argp, lan, inc, plx, mtot, mass=0):
     mean_motion = 2*np.pi/(period) # in rad/day
 
     # compute mean anomaly (size: n_orbs x n_dates)
-    manom = (mean_motion*epochs - 2*np.pi*tau) #% 2*np.pi
-
+    manom = (mean_motion*epochs - 2*np.pi*tau) % (2.0*np.pi)
+    
     # compute eccentric anomalies (size: n_orbs x n_dates)
     eanom = _calc_ecc_anom(manom, ecc)
     

--- a/orbitize/kepler.py
+++ b/orbitize/kepler.py
@@ -6,7 +6,7 @@ import astropy.units as u
 import astropy.constants as consts
 
 
-def calc_orbit(epochs, sma, ecc, tau, argp, lan, inc, plx, mtot, mass=None):
+def calc_orbit(epochs, sma, ecc, tau, argp, lan, inc, plx, mtot, mass=None, tolerance=1e-9, max_iter=100):
     """
     Returns the separation and radial velocity of the body given array of
     orbital parameters (size n_orbs) at given epochs (array of size n_dates)
@@ -23,7 +23,9 @@ def calc_orbit(epochs, sma, ecc, tau, argp, lan, inc, plx, mtot, mass=None):
         inc (np.array): inclination [radians]
         plx (np.array): parallax [mas]
         mtot (np.array): total mass [Solar masses]
-        mass (np.array): mass of the body [Solar masses]. For planets mass ~ 0 (default)
+        mass (np.array, optional): mass of the body [Solar masses]. For planets mass ~ 0 (default)
+        tolerance (float, optional): absolute tolerance of iterative computation. Defaults to 1e-9.
+        max_iter (int, optional): maximum number of iterations before switching. Defaults to 100.
 
     Return:
         raoff (np.array): 2-D array (n_orbs x n_dates) of RA offsets between the bodies (origin is at the other body)
@@ -54,7 +56,7 @@ def calc_orbit(epochs, sma, ecc, tau, argp, lan, inc, plx, mtot, mass=None):
     manom = (mean_motion*epochs[:, None] - 2*np.pi*tau) % (2.0*np.pi)
 
     # compute eccentric anomalies (size: n_orbs x n_dates)
-    eanom = _calc_ecc_anom(manom, ecc_arr)
+    eanom = _calc_ecc_anom(manom, ecc_arr, tolerance=tolerance, max_iter=max_iter)
 
     # compute the true anomalies (size: n_orbs x n_dates)
     # Note: matrix multiplication makes the shapes work out here and below

--- a/tests/test_kepler_solver.py
+++ b/tests/test_kepler_solver.py
@@ -16,9 +16,6 @@ def test_analytical_ecc_anom_solver():
     eccs=np.linspace(0.95,0.999999,100)
     for ee in eccs:
         ecc_anoms = kepler._calc_ecc_anom(mean_anoms,ee,tolerance=1e-9)
-        # the solver changes the values of mm to be within 0 to pi
-        ind_change = np.where(ecc_anoms > np.pi)
-        ecc_anoms[ind_change] = (2.0 * np.pi) - ecc_anoms[ind_change]
         calc_mm = ecc_anoms - ee*np.sin(ecc_anoms) # plug solutions into Kepler's equation
         for meas, truth in zip(calc_mm, mean_anoms):
             assert truth == pytest.approx(meas, abs=1e-8)

--- a/tests/test_kepler_solver.py
+++ b/tests/test_kepler_solver.py
@@ -86,6 +86,7 @@ def test_orbit_e03_array():
     true_vz    = np.array([[0.86448656,  0.97591289],
                            [0.86448656,  0.97591289],
                            [0.86448656,  0.97591289]])
+
     for ii in range(0,3):
         for meas, truth in zip(raoffs[ii,:], true_raoff[ii,:]):
             assert truth == pytest.approx(meas, abs=threshold)

--- a/tests/test_kepler_solver.py
+++ b/tests/test_kepler_solver.py
@@ -154,7 +154,8 @@ def test_orbit_with_mass_array():
     plx = np.array([50,50,50])
     mtot = np.array([1.5,1.5,1.5])
     epochs = np.array([1000, 1101.4])
-    raoffs, deoffs, vzs = kepler.calc_orbit(epochs, sma, ecc, tau, argp, lan, inc, plx, mtot, mtot[0]/2)
+    mass = mtot/2
+    raoffs, deoffs, vzs = kepler.calc_orbit(epochs, sma, ecc, tau, argp, lan, inc, plx, mtot, mass=mass)
 
     true_raoff = np.array([[ 0.15286786,  0.18039408],
                            [ 0.15286786,  0.18039408],

--- a/tests/test_kepler_solver.py
+++ b/tests/test_kepler_solver.py
@@ -7,6 +7,10 @@ import orbitize.kepler as kepler
 
 threshold = 1e-8
 
+def angle_diff(ang1, ang2):
+    # Return the difference between two angles
+    return np.arctan2(np.sin(ang1 - ang2), np.cos(ang1 - ang2))
+
 def test_analytical_ecc_anom_solver():
     """
     Test orbitize.kepler._calc_ecc_anom() in the analytical solver regime (e > 0.95) by comparing the mean anomaly computed from
@@ -16,9 +20,9 @@ def test_analytical_ecc_anom_solver():
     eccs=np.linspace(0.95,0.999999,100)
     for ee in eccs:
         ecc_anoms = kepler._calc_ecc_anom(mean_anoms,ee,tolerance=1e-9)
-        calc_mm = ecc_anoms - ee*np.sin(ecc_anoms) # plug solutions into Kepler's equation
+        calc_mm = (ecc_anoms - ee*np.sin(ecc_anoms)) % (2*np.pi) # plug solutions into Kepler's equation
         for meas, truth in zip(calc_mm, mean_anoms):
-            assert truth == pytest.approx(meas, abs=1e-8)
+            assert angle_diff(meas, truth) == pytest.approx(0.0, abs=1e-8)
 
 def test_iterative_ecc_anom_solver():
     """
@@ -29,9 +33,9 @@ def test_iterative_ecc_anom_solver():
     eccs=np.linspace(0,0.9499999,100)
     for ee in eccs:
         ecc_anoms = kepler._calc_ecc_anom(mean_anoms,ee,tolerance=1e-9)
-        calc_ma = ecc_anoms - ee*np.sin(ecc_anoms) # plug solutions into Kepler's equation
+        calc_ma = (ecc_anoms - ee*np.sin(ecc_anoms)) % (2*np.pi) # plug solutions into Kepler's equation
         for meas, truth in zip(calc_ma, mean_anoms):
-            assert truth == pytest.approx(meas, abs=1e-8)
+            assert angle_diff(meas, truth) == pytest.approx(0.0, abs=1e-8)
 
 def test_orbit_e03():
     """

--- a/tests/test_kepler_solver.py
+++ b/tests/test_kepler_solver.py
@@ -175,6 +175,30 @@ def test_orbit_with_mass_array():
         for meas, truth in zip(vzs[ii,:], true_vz[ii,:]):
             assert truth == pytest.approx(meas, abs=threshold)
 
+def test_orbit_scalar():
+    """
+    Test orbitize.kepler.calc_orbit() with scalar values
+    """
+    sma = 10
+    ecc = 0.3
+    tau = 0.3
+    argp = 0.5
+    lan = 1.5
+    inc = 3
+    plx = 50
+    mtot = 1.5
+    epochs = 1000
+    raoffs, deoffs, vzs = kepler.calc_orbit(epochs, sma, ecc, tau, argp, lan, inc, plx, mtot)
+
+    true_raoff = 0.15286786
+    true_deoff = -0.46291038
+    true_vz    = 0.86448656
+
+    assert true_raoff == pytest.approx(raoffs, abs=threshold)
+    assert true_deoff == pytest.approx(deoffs, abs=threshold)
+    assert true_vz    == pytest.approx(vzs, abs=threshold)
+
+
 if __name__ == "__main__":
     test_analytical_ecc_anom_solver()
     test_iterative_ecc_anom_solver()
@@ -183,3 +207,4 @@ if __name__ == "__main__":
     test_orbit_e99()
     test_orbit_with_mass()
     test_orbit_with_mass_array()
+    test_orbit_scalar()


### PR DESCRIPTION
A few modifications:

- Element, parallax and mtot vectors are now converted into (n_orbs, n_dates) arrays. A bit clunky. The alternative is to use [:, None] indexing, although that would have to be put everywhere in the code, so maybe this is neater?
- manom now wrapped between 0->2pi. This significantly changes the output for high eccentricity orbits.
- raoff, deoff and vz calculation vectorized
- eanom calculation vectorized
- Split the newton solver into its own function.
- Various modifications for consistency, and removed some unused variables.