### PR TITLE
Multi-threading support for MCMC samplers

### DIFF
--- a/orbitize/__init__.py
+++ b/orbitize/__init__.py
@@ -7,9 +7,6 @@ __version__ = '0.1.0'
 def _pickle_method(method):
     func_name = method.im_func.__name__
     obj = method.im_self
-    # Remove the pool object from the emcee sampler objects
-    if obj.__class__.__name__=='EnsembleMCMC' or obj.__class__.__name__=='PTMCMC':
-        obj.sampler.pool = None
     cls = method.im_class
     return _unpickle_method, (func_name, obj, cls)
 
@@ -27,6 +24,3 @@ def _unpickle_method(func_name, obj, cls):
 if sys.version_info[0] < 3:
     import copy_reg
     copy_reg.pickle(types.MethodType, _pickle_method, _unpickle_method)
-else: # Attempt to make this work in py3 but it doesn't seem to do it
-    import copyreg
-    copyreg.pickle(types.MethodType, _pickle_method, _unpickle_method)

--- a/orbitize/__init__.py
+++ b/orbitize/__init__.py
@@ -7,9 +7,11 @@ __version__ = '0.1.0'
 def _pickle_method(method):
     func_name = method.im_func.__name__
     obj = method.im_self
+    # Remove the pool object from the emcee sampler objects
+    if obj.__class__.__name__=='EnsembleMCMC' or obj.__class__.__name__=='PTMCMC':
+        obj.sampler.pool = None
     cls = method.im_class
     return _unpickle_method, (func_name, obj, cls)
-
 
 def _unpickle_method(func_name, obj, cls):
     for cls in cls.mro():
@@ -25,3 +27,6 @@ def _unpickle_method(func_name, obj, cls):
 if sys.version_info[0] < 3:
     import copy_reg
     copy_reg.pickle(types.MethodType, _pickle_method, _unpickle_method)
+else: # Attempt to make this work in py3 but it doesn't seem to do it
+    import copyreg
+    copyreg.pickle(types.MethodType, _pickle_method, _unpickle_method)

--- a/orbitize/sampler.py
+++ b/orbitize/sampler.py
@@ -97,8 +97,7 @@ class PTMCMC(Sampler):
     """
     Parallel-Tempered MCMC Sampler using the emcee Affine-infariant sampler
 
-    NOTE: Does not currnetly support multithreading because orbitize classes are not yet pickleable.
-    NOTE: emcee will no longer support PTSampler in emcee v3.0. Would need to use ptemcee instead
+    NOTE: emcee will no longer support PTSampler in emcee v3.0. Would need to use ptemcee instead (or use the EnsembleSampler)
 
     Args:
         lnlike (string): name of likelihood function in ``lnlike.py``

--- a/tests/test_mcmc.py
+++ b/tests/test_mcmc.py
@@ -22,9 +22,9 @@ def test_pt_mcmc_runs(num_threads=1):
     mcmc = sampler.PTMCMC(chi2_lnlike, orbit, 2, 100, num_threads=num_threads)
 
     # run it a little
-    mcmc.run_sampler(10, 1)
+    emcee_sampler_obj = mcmc.run_sampler(10, 1)
 
-    print(mcmc.sampler.chain[0, 0])
+    print(emcee_sampler_obj.chain[0, 0])
 
 def test_ensemble_mcmc_runs(num_threads=1):
     """
@@ -44,12 +44,12 @@ def test_ensemble_mcmc_runs(num_threads=1):
     mcmc = sampler.EnsembleMCMC(chi2_lnlike, orbit, 100, num_threads=num_threads)
 
     # run it a little
-    mcmc.run_sampler(10, 1)
+    emcee_sampler_obj = mcmc.run_sampler(10, burn_steps=1)
 
-    print(mcmc.sampler.chain[0, 0])
+    print(emcee_sampler_obj.chain[0, 0])
 
 if __name__ == "__main__":
     test_pt_mcmc_runs(num_threads=1)
     test_pt_mcmc_runs(num_threads=4)
     test_ensemble_mcmc_runs(num_threads=1)
-    test_ensemble_mcmc_runs(num_threads=4)
+    test_ensemble_mcmc_runs(num_threads=8)

--- a/tests/test_mcmc.py
+++ b/tests/test_mcmc.py
@@ -4,7 +4,7 @@ import orbitize.system as system
 import orbitize.read_input as read_input
 from orbitize.lnlike import chi2_lnlike
 
-def test_ptmcmc_runs():
+def test_pt_mcmc_runs():
     """
     Tests the PTMCMC sampler by making sure it even runs
     """
@@ -26,5 +26,28 @@ def test_ptmcmc_runs():
 
     print(mcmc.sampler.chain[0, 0])
 
+def test_ensemble_mcmc_runs():
+    """
+    Tests the EnsembleMCMC sampler by making sure it even runs
+    """
+    # use the test_csv dir
+    testdir = os.path.dirname(os.path.abspath(__file__))
+    input_file = os.path.join(testdir, 'test_val.csv')
+    data_table = read_input.read_formatted_file(input_file)
+    # Manually set 'object' column of data table
+    data_table['object'] = 1
+
+    # construct the system
+    orbit = system.System(1, data_table, 1, 0.01)
+
+    # construct sampler
+    mcmc = sampler.EnsembleMCMC(chi2_lnlike, orbit, 100, num_threads=1)
+
+    # run it a little
+    mcmc.run_sampler(10, 1)
+
+    print(mcmc.sampler.chain[0, 0])
+
 if __name__ == "__main__":
-    test_ptmcmc_runs()
+    #test_pt_mcmc_runs()
+    test_ensemble_mcmc_runs()

--- a/tests/test_mcmc.py
+++ b/tests/test_mcmc.py
@@ -6,9 +6,9 @@ from orbitize.lnlike import chi2_lnlike
 
 def test_ptmcmc_runs():
     """
-    Tests the PTMCMC sampler by making sure it even runs 
+    Tests the PTMCMC sampler by making sure it even runs
     """
-    # use the test_csv dir 
+    # use the test_csv dir
     testdir = os.path.dirname(os.path.abspath(__file__))
     input_file = os.path.join(testdir, 'test_val.csv')
     data_table = read_input.read_formatted_file(input_file)
@@ -19,7 +19,7 @@ def test_ptmcmc_runs():
     orbit = system.System(1, data_table, 1, 0.01)
 
     # construct sampler
-    mcmc = sampler.PTMCMC(chi2_lnlike, orbit, 2, 100)
+    mcmc = sampler.PTMCMC(chi2_lnlike, orbit, 2, 100, num_threads=1)
 
     # run it a little
     mcmc.run_sampler(10, 1)

--- a/tests/test_mcmc.py
+++ b/tests/test_mcmc.py
@@ -4,7 +4,7 @@ import orbitize.system as system
 import orbitize.read_input as read_input
 from orbitize.lnlike import chi2_lnlike
 
-def test_pt_mcmc_runs():
+def test_pt_mcmc_runs(num_threads=1):
     """
     Tests the PTMCMC sampler by making sure it even runs
     """
@@ -19,14 +19,14 @@ def test_pt_mcmc_runs():
     orbit = system.System(1, data_table, 1, 0.01)
 
     # construct sampler
-    mcmc = sampler.PTMCMC(chi2_lnlike, orbit, 2, 100, num_threads=1)
+    mcmc = sampler.PTMCMC(chi2_lnlike, orbit, 2, 100, num_threads=num_threads)
 
     # run it a little
     mcmc.run_sampler(10, 1)
 
     print(mcmc.sampler.chain[0, 0])
 
-def test_ensemble_mcmc_runs():
+def test_ensemble_mcmc_runs(num_threads=1):
     """
     Tests the EnsembleMCMC sampler by making sure it even runs
     """
@@ -41,7 +41,7 @@ def test_ensemble_mcmc_runs():
     orbit = system.System(1, data_table, 1, 0.01)
 
     # construct sampler
-    mcmc = sampler.EnsembleMCMC(chi2_lnlike, orbit, 100, num_threads=1)
+    mcmc = sampler.EnsembleMCMC(chi2_lnlike, orbit, 100, num_threads=num_threads)
 
     # run it a little
     mcmc.run_sampler(10, 1)
@@ -49,5 +49,7 @@ def test_ensemble_mcmc_runs():
     print(mcmc.sampler.chain[0, 0])
 
 if __name__ == "__main__":
-    #test_pt_mcmc_runs()
-    test_ensemble_mcmc_runs()
+    test_pt_mcmc_runs(num_threads=1)
+    test_pt_mcmc_runs(num_threads=4)
+    test_ensemble_mcmc_runs(num_threads=1)
+    test_ensemble_mcmc_runs(num_threads=4)


### PR DESCRIPTION
sampler object's initialization can specify `nthreads` for parallelization. 

Since `emcee` will remove their PT sampler in the next release, I've added the Ensemble Sampler from `emcee` as an alternative (a good replacement might be `ptemcee`)

Addresses Issue #30 