### PR TITLE
Do not include negative values in the Gaussian prior

### DIFF
--- a/orbitize/priors.py
+++ b/orbitize/priors.py
@@ -94,10 +94,10 @@ class GaussianPrior(Prior):
         """
         lnprob = -0.5*np.log(2.*np.pi*self.sigma) - 0.5*((element_array - self.mu) / self.sigma)**2
 
-        bad_samples = np.where(samples <= 0)[0]
+        bad_samples = np.where(element_array <= 0)[0]
         lnprob[bad_samples] = -np.inf
 
-        return lnprob
+        return lnprob 
 
 class JeffreysPrior(Prior):
     """

--- a/orbitize/priors.py
+++ b/orbitize/priors.py
@@ -73,7 +73,7 @@ class GaussianPrior(Prior):
 
             while bad != 0:
 
-                bad_samples = np.where(samples <= 0)[0]
+                bad_samples = np.where(samples < 0)[0]
                 bad = len(bad_samples)
 
                 samples[bad_samples] = np.random.normal(
@@ -101,7 +101,7 @@ class GaussianPrior(Prior):
 
         if self.no_negatives:
 
-            bad_samples = np.where(element_array <= 0)[0]
+            bad_samples = np.where(element_array < 0)[0]
             lnprob[bad_samples] = -np.inf
 
         return lnprob

--- a/orbitize/priors.py
+++ b/orbitize/priors.py
@@ -48,13 +48,15 @@ class GaussianPrior(Prior):
     def __repr__(self):
         return "Gaussian"
 
-    def draw_samples(self, num_samples):
+    def draw_samples(self, num_samples, no_negatives=True):
         """
         Draw positive samples from a Gaussian distribution.
         Negative samples will not be returned. 
 
         Args:
             num_samples (float): the number of samples to generate
+            no_negatives (bool): if True, only positive samples will
+                be drawn (default: False).
 
         Returns:
             numpy array of float: samples drawn from the appropriate
@@ -66,18 +68,20 @@ class GaussianPrior(Prior):
         )        
         bad = np.inf
 
-        while bad != 0:
+        if no_negatives:
 
-            bad_samples = np.where(samples <= 0)[0]
-            bad = len(bad_samples)
+            while bad != 0:
 
-            samples[bad_samples] = np.random.normal(
-                loc=self.mu, scale=self.sigma, size=bad
-            )   
+                bad_samples = np.where(samples <= 0)[0]
+                bad = len(bad_samples)
+
+                samples[bad_samples] = np.random.normal(
+                    loc=self.mu, scale=self.sigma, size=bad
+                )   
 
         return samples
 
-    def compute_lnprob(self, element_array):
+    def compute_lnprob(self, element_array, no_negatives=True):
         """
         Compute log(probability) of an array of numbers wrt a Gaussian distibution.
         Negative numbers return a probability of -inf.
@@ -86,6 +90,8 @@ class GaussianPrior(Prior):
             element_array (float or np.array of float): array of numbers. We want the 
                 probability of drawing each of these from the appopriate Gaussian 
                 distribution
+            no_negatives (bool): if True, the log(probability) of negative numbers
+                will be -inf (default:True).
 
         Returns:
             numpy array of float: array of log(probability) values, 
@@ -94,10 +100,12 @@ class GaussianPrior(Prior):
         """
         lnprob = -0.5*np.log(2.*np.pi*self.sigma) - 0.5*((element_array - self.mu) / self.sigma)**2
 
-        bad_samples = np.where(element_array <= 0)[0]
-        lnprob[bad_samples] = -np.inf
+        if no_negatives:
 
-        return lnprob 
+            bad_samples = np.where(samples <= 0)[0]
+            lnprob[bad_samples] = -np.inf
+
+        return lnprob
 
 class JeffreysPrior(Prior):
     """

--- a/orbitize/priors.py
+++ b/orbitize/priors.py
@@ -50,7 +50,8 @@ class GaussianPrior(Prior):
 
     def draw_samples(self, num_samples):
         """
-        Draw samples from a Gaussian distribution.
+        Draw positive samples from a Gaussian distribution.
+        Negative samples will not be returned. 
 
         Args:
             num_samples (float): the number of samples to generate
@@ -59,14 +60,27 @@ class GaussianPrior(Prior):
             numpy array of float: samples drawn from the appropriate
             Gaussian distribution. Array has length `num_samples`. 
         """
+
         samples = np.random.normal(
             loc=self.mu, scale=self.sigma, size=num_samples
-            )
+        )        
+        bad = np.inf
+
+        while bad != 0:
+
+            bad_samples = np.where(samples <= 0)[0]
+            bad = len(bad_samples)
+
+            samples[bad_samples] = np.random.normal(
+                loc=self.mu, scale=self.sigma, size=bad
+            )   
+
         return samples
 
     def compute_lnprob(self, element_array):
         """
         Compute log(probability) of an array of numbers wrt a Gaussian distibution.
+        Negative numbers return a probability of -inf.
 
         Args:
             element_array (float or np.array of float): array of numbers. We want the 
@@ -79,6 +93,9 @@ class GaussianPrior(Prior):
             in the input `element_array`.
         """
         lnprob = -0.5*np.log(2.*np.pi*self.sigma) - 0.5*((element_array - self.mu) / self.sigma)**2
+
+        bad_samples = np.where(samples <= 0)[0]
+        lnprob[bad_samples] = -np.inf
 
         return lnprob
 

--- a/orbitize/priors.py
+++ b/orbitize/priors.py
@@ -38,25 +38,26 @@ class GaussianPrior(Prior):
     Args:
         mu (float): mean of the distribution
         sigma (float): standard deviation of the distribution
+        no_negatives (bool): if True, only positive values will be drawn from
+            this prior, and the probability of negative values will be 0 (default:True).
 
     (written) Sarah Blunt, 2018
     """
-    def __init__(self, mu, sigma):
+    def __init__(self, mu, sigma, no_negatives=True):
         self.mu = mu
         self.sigma = sigma
+        self.no_negatives = no_negatives
 
     def __repr__(self):
         return "Gaussian"
 
-    def draw_samples(self, num_samples, no_negatives=True):
+    def draw_samples(self, num_samples):
         """
         Draw positive samples from a Gaussian distribution.
         Negative samples will not be returned. 
 
         Args:
             num_samples (float): the number of samples to generate
-            no_negatives (bool): if True, only positive samples will
-                be drawn (default: False).
 
         Returns:
             numpy array of float: samples drawn from the appropriate
@@ -68,7 +69,7 @@ class GaussianPrior(Prior):
         )        
         bad = np.inf
 
-        if no_negatives:
+        if self.no_negatives:
 
             while bad != 0:
 
@@ -81,7 +82,7 @@ class GaussianPrior(Prior):
 
         return samples
 
-    def compute_lnprob(self, element_array, no_negatives=True):
+    def compute_lnprob(self, element_array):
         """
         Compute log(probability) of an array of numbers wrt a Gaussian distibution.
         Negative numbers return a probability of -inf.
@@ -90,8 +91,6 @@ class GaussianPrior(Prior):
             element_array (float or np.array of float): array of numbers. We want the 
                 probability of drawing each of these from the appopriate Gaussian 
                 distribution
-            no_negatives (bool): if True, the log(probability) of negative numbers
-                will be -inf (default:True).
 
         Returns:
             numpy array of float: array of log(probability) values, 
@@ -100,7 +99,7 @@ class GaussianPrior(Prior):
         """
         lnprob = -0.5*np.log(2.*np.pi*self.sigma) - 0.5*((element_array - self.mu) / self.sigma)**2
 
-        if no_negatives:
+        if self.no_negatives:
 
             bad_samples = np.where(samples <= 0)[0]
             lnprob[bad_samples] = -np.inf

--- a/orbitize/priors.py
+++ b/orbitize/priors.py
@@ -101,7 +101,7 @@ class GaussianPrior(Prior):
 
         if self.no_negatives:
 
-            bad_samples = np.where(samples <= 0)[0]
+            bad_samples = np.where(element_array <= 0)[0]
             lnprob[bad_samples] = -np.inf
 
         return lnprob

--- a/orbitize/results.py
+++ b/orbitize/results.py
@@ -360,6 +360,7 @@ class Results(object):
 
         # Create a linearly increasing colormap for our range of epochs
         norm = mpl.colors.Normalize(vmin=np.min(epochs), vmax=np.max(epochs[-1,:]))
+
         norm_yr = mpl.colors.Normalize(
             vmin=np.min(Time(epochs,format='mjd').decimalyear), 
             vmax=np.max(Time(epochs,format='mjd').decimalyear)

--- a/tests/test_priors.py
+++ b/tests/test_priors.py
@@ -7,7 +7,7 @@ import orbitize.priors as priors
 threshold = 1e-1
 
 initialization_inputs = {
-	priors.GaussianPrior : [100., 1.], 
+	priors.GaussianPrior : [1000., 1.], 
 	priors.JeffreysPrior : [1., 2.], 
 	priors.UniformPrior : [0., 1.], 
 	priors.SinPrior : [], 
@@ -15,7 +15,7 @@ initialization_inputs = {
 }
 
 expected_means_mins_maxes = {
-	priors.GaussianPrior : (100.,0.,np.inf), 
+	priors.GaussianPrior : (1000.,0.,np.inf), 
 	priors.JeffreysPrior : (1/np.log(2),1., 2.), 
 	priors.UniformPrior : (0.5, 0., 1.), 
 	priors.SinPrior : (np.pi/2., 0., np.pi), 
@@ -23,7 +23,7 @@ expected_means_mins_maxes = {
 }
 
 lnprob_inputs = {
-	priors.GaussianPrior : np.array([-3.0, np.inf, 100., 99.]),
+	priors.GaussianPrior : np.array([-3.0, np.inf, 1000., 999.]),
 	priors.JeffreysPrior : np.array([-1., 0., 1., 1.5, 2., 2.5]),
 	priors.UniformPrior : np.array([0., 0.5, 1., -1., 2.]),
 	priors.SinPrior : np.array([0., np.pi/2., np.pi, 10., -1.]),
@@ -31,7 +31,7 @@ lnprob_inputs = {
 }
 
 expected_probs = {
-	priors.GaussianPrior : np.array([0., 0., nm(100.,1.).pdf(100.), nm(100.,1.).pdf(99.)]),
+	priors.GaussianPrior : np.array([0., 0., nm(1000.,1.).pdf(1000.), nm(1000.,1.).pdf(999.)]),
 	priors.JeffreysPrior : np.array([0., 0., 1., 2./3., 0.5, 0.])/np.log(2),
 	priors.UniformPrior : np.array([1., 1., 1., 0., 0.]),
 	priors.SinPrior : np.array([0., 0.5, 0., 0., 0.]),

--- a/tests/test_priors.py
+++ b/tests/test_priors.py
@@ -7,7 +7,7 @@ import orbitize.priors as priors
 threshold = 1e-1
 
 initialization_inputs = {
-	priors.GaussianPrior : [0., 1.], 
+	priors.GaussianPrior : [100., 1.], 
 	priors.JeffreysPrior : [1., 2.], 
 	priors.UniformPrior : [0., 1.], 
 	priors.SinPrior : [], 
@@ -15,7 +15,7 @@ initialization_inputs = {
 }
 
 expected_means_mins_maxes = {
-	priors.GaussianPrior : (0.,-np.inf,np.inf), 
+	priors.GaussianPrior : (100.,0.,np.inf), 
 	priors.JeffreysPrior : (1/np.log(2),1., 2.), 
 	priors.UniformPrior : (0.5, 0., 1.), 
 	priors.SinPrior : (np.pi/2., 0., np.pi), 
@@ -23,7 +23,7 @@ expected_means_mins_maxes = {
 }
 
 lnprob_inputs = {
-	priors.GaussianPrior : np.array([0., -np.inf, np.inf, 3., 3.]),
+	priors.GaussianPrior : np.array([-3.0, np.inf, 100., 99.]),
 	priors.JeffreysPrior : np.array([-1., 0., 1., 1.5, 2., 2.5]),
 	priors.UniformPrior : np.array([0., 0.5, 1., -1., 2.]),
 	priors.SinPrior : np.array([0., np.pi/2., np.pi, 10., -1.]),
@@ -31,7 +31,7 @@ lnprob_inputs = {
 }
 
 expected_probs = {
-	priors.GaussianPrior : np.array([nm(0,1).pdf(0), 0., 0., nm(0,1).pdf(3), nm(0,1).pdf(-3)]),
+	priors.GaussianPrior : np.array([0., 0., nm(100.,1.).pdf(100.), nm(100.,1.).pdf(99.)]),
 	priors.JeffreysPrior : np.array([0., 0., 1., 2./3., 0.5, 0.])/np.log(2),
 	priors.UniformPrior : np.array([1., 1., 1., 0., 0.]),
 	priors.SinPrior : np.array([0., 0.5, 0., 0., 0.]),
@@ -65,6 +65,7 @@ def test_compute_lnprob():
 		values2test = lnprob_inputs[Prior]
 
 		lnprobs = TestPrior.compute_lnprob(values2test)
+
 		assert np.log(expected_probs[Prior]) == pytest.approx(lnprobs, abs=threshold)
 
 


### PR DESCRIPTION
This was causing unphysical (negative) stellar masses to be returned. Fixed.