### PR TITLE
Tau utilities and customization

### DIFF
--- a/orbitize/basis.py
+++ b/orbitize/basis.py
@@ -1,0 +1,65 @@
+import numpy as np
+import astropy.units as u
+
+def tau_to_t0(tau, ref_epoch, period, after_date=None):
+    """
+    Convert tau (epoch of periastron in fractional orbital period after ref epoch) to
+    T0 (date in days, usually MJD, but works with whatever system ref_epoch is given in)
+
+    Args:
+        tau (float or np.array): value of tau to convert
+        ref_epoch (float or np.array): date (in days, typically MJD) that tau is defined relative to
+        period (float or np.array): period (in years) that tau is noralized with
+        after_date (float): T0 will be the first periastron after this date. If None, use ref_epoch.
+
+    Returns:
+        t0 (float or np.array): corresponding T0 of the taus
+    """
+    period_days = period * u.year.to(u.day)
+
+    t0 = tau * (period_days) + ref_epoch
+
+    if after_date is not None:
+        num_periods = (after_date - t0)/period_days
+        num_periods = int(np.ceil(num_periods))
+        
+        t0 += num_periods * period_days
+
+    return t0
+
+def t0_to_tau(t0, ref_epoch, period):
+    """
+    Convert T0 to tau
+
+    Args:
+        t0 (float or np.array): value to T0 to convert (days, typically MJD)
+        ref_epoch (float or np.array): reference epoch (in days) that tau is defined from. Same system as t0 (e.g., MJD)
+        period (float or np.array): period (in years) that tau is defined by
+
+    Returns:
+        tau (float or np.array): corresponding taus
+    """
+    tau = (t0 - ref_epoch)/(period * u.year.to(u.day))
+    tau %= 1
+
+    return tau
+
+def switch_tau_epoch(old_tau, old_epoch, new_epoch, period):
+    """
+    Convert tau to another tau that uses a different referench epoch
+
+    Args:
+        old_tau (float or np.array): old tau to convert
+        old_epoch (float or np.array): old reference epoch (days, typically MJD)
+        new_epoch (float or np.array): new reference epoch (days, same system as old_epoch)
+        period (float or np.array): orbital period (years)
+
+    Returns:
+        new_tau (float or np.array): new taus
+    """
+    period_days = period * u.year.to(u.day)
+
+    t0 = tau_to_t0(old_tau, old_epoch, period)
+    new_tau = t0_to_tau(t0, new_epoch, period)
+
+    return new_tau

--- a/orbitize/driver.py
+++ b/orbitize/driver.py
@@ -24,6 +24,8 @@ class Driver(object):
         plx_err (float, optional): uncertainty on ``plx`` [mas]
         lnlike (str, optional): name of function in ``orbitize.lnlike`` that will
             be used to compute likelihood. (default="chi2_lnlike")
+        system_kwargs (dict, optional): ``restrict_angle_ranges``, ``ref_tau_epoch``, 
+            ``results`` for ``orbitize.system.System``. 
         mcmc_kwargs (dict, optional): ``num_temps``, ``num_walkers``, and ``num_threads``
             kwargs for ``orbitize.sampler.MCMC``
 
@@ -31,7 +33,8 @@ class Driver(object):
     """
     def __init__(self, input_data, sampler_str,
                  num_secondary_bodies, system_mass, plx,
-                 mass_err=0, plx_err=0, lnlike='chi2_lnlike', mcmc_kwargs=None):
+                 mass_err=0, plx_err=0, lnlike='chi2_lnlike', 
+                 system_kwargs=None, mcmc_kwargs=None):
 
         # Read in data
         # Try to interpret input as a filename first
@@ -45,10 +48,13 @@ class Driver(object):
             except:
                 raise Exception('Invalid value of input_data for Driver')
 
+        if system_kwargs is None:
+            system_kwargs = {}
+
         # Initialize System object which stores data & sets priors
         self.system = orbitize.system.System(
             num_secondary_bodies, data_table, system_mass,
-            plx, mass_err=mass_err, plx_err=plx_err
+            plx, mass_err=mass_err, plx_err=plx_err, **system_kwargs
         )
 
         # Initialize Sampler object, which stores information about

--- a/orbitize/kepler.py
+++ b/orbitize/kepler.py
@@ -14,7 +14,7 @@ equation solver. Falling back to the slower NumPy implementation.")
     cext = False
 
 
-def calc_orbit(epochs, sma, ecc, inc, argp, lan, tau, plx, mtot, mass=None, tolerance=1e-9, max_iter=100):
+def calc_orbit(epochs, sma, ecc, inc, argp, lan, tau, plx, mtot, mass=None, tau_ref_epoch=0, tolerance=1e-9, max_iter=100):
     """
     Returns the separation and radial velocity of the body given array of
     orbital parameters (size n_orbs) at given epochs (array of size n_dates)
@@ -32,6 +32,7 @@ def calc_orbit(epochs, sma, ecc, inc, argp, lan, tau, plx, mtot, mass=None, tole
         plx (np.array): parallax [mas]
         mtot (np.array): total mass [Solar masses]
         mass (np.array, optional): mass of the body [Solar masses]. For planets mass ~ 0 (default)
+        tau_ref_epoch (float, optional): reference date that tau is defined with respect to (i.e., tau=0)
         tolerance (float, optional): absolute tolerance of iterative computation. Defaults to 1e-9.
         max_iter (int, optional): maximum number of iterations before switching. Defaults to 100.
 
@@ -66,7 +67,7 @@ def calc_orbit(epochs, sma, ecc, inc, argp, lan, tau, plx, mtot, mass=None, tole
     mean_motion = 2*np.pi/(period) # in rad/day
 
     # # compute mean anomaly (size: n_orbs x n_dates)
-    manom = (mean_motion*epochs[:, None] - 2*np.pi*tau) % (2.0*np.pi)
+    manom = (mean_motion*(epochs[:, None] - tau_ref_epoch) - 2*np.pi*tau) % (2.0*np.pi)
 
     # compute eccentric anomalies (size: n_orbs x n_dates)
     eanom = _calc_ecc_anom(manom, ecc_arr, tolerance=tolerance, max_iter=max_iter)

--- a/orbitize/results.py
+++ b/orbitize/results.py
@@ -38,6 +38,7 @@ class Results(object):
             parameters in the fit (default: None).
         lnlike (np.array of float): M array of log-likelihoods corresponding to
             the orbits described in ``post`` (default: None).
+        tau_ref_epoch (float): date (in days, typically MJD) that tau is defined relative to
 
     The ``post`` array is in the following order::
 
@@ -48,7 +49,7 @@ class Results(object):
         [parallax, total mass]
 
     where 1 corresponds to the first orbiting object, 2 corresponds
-    to the second, etc. 
+    to the second, etc.
 
     Written: Henry Ngo, Sarah Blunt, 2018
     """
@@ -96,12 +97,13 @@ class Results(object):
         MCMC sampler has the ``lnlike`` attribute set. For OFTI, ``lnlike`` is None and
         it is not saved.
 
-        HDF5: ``sampler_name`` is an attribute of the root group. ``post`` and ``lnlike``
-        are datasets that are members of the root group.
+        HDF5: ``sampler_name`` and ``tau_ref_epcoh`` are attributes of the root group.
+        ``post`` and ``lnlike`` are datasets that are members of the root group.
 
         FITS: Data is saved as Binary FITS Table to the *first extension* HDU.
         After reading with something like ``hdu = astropy.io.fits.open(file)``,
         ``hdu[1].header['SAMPNAME']`` returns the ``sampler_name``.
+        ``hdu[1].header['TAU_REF']`` returns the ``tau_ref_epoch``.
         ``hdu[1].data`` returns a ``Table`` with two columns. The first column
         contains the post array, and the second column contains the lnlike array
 
@@ -173,7 +175,7 @@ class Results(object):
 
             # Get sampler_name from header
             sampler_name = table_hdu.header['SAMPNAME']
-            
+
             # get tau reference epoch
             if 'TAU_REF' in table_hdu.header:
                 tau_ref_epoch = table_hdu.header['TAU_REF']
@@ -201,7 +203,7 @@ class Results(object):
             # otherwise only proceed if the sampler_names match
             elif self.sampler_name != sampler_name:
                 raise Exception('Unable to append file {} to Results object. sampler_name of object and file do not match'.format(filename))
-            
+
             # if no tau reference epoch is set, use input file's value
             if self.tau_ref_epoch is None:
                 self.tau_ref_epoch = tau_ref_epoch
@@ -309,7 +311,7 @@ class Results(object):
     def plot_orbits(self, parallax=None, total_mass=None, object_mass=0,
                     object_to_plot=1, start_mjd=51544.,
                     num_orbits_to_plot=100, num_epochs_to_plot=100,
-                    square_plot=True, show_colorbar=True, cmap=cmap, 
+                    square_plot=True, show_colorbar=True, cmap=cmap,
                     sep_pa_color='lightgrey', sep_pa_end_year=2025.0,
                     cbar_param='epochs'):
 
@@ -337,11 +339,11 @@ class Results(object):
             show_colorbar (Boolean): Displays colorbar to the right of the plot [True]
             cmap (matplotlib.cm.ColorMap): color map to use for making orbit tracks
                 (default: modified Purples_r)
-            sep_pa_color (string): any valid matplotlib color string, used to set the 
+            sep_pa_color (string): any valid matplotlib color string, used to set the
                 color of the orbit tracks in the Sep/PA panels (default: 'lightgrey').
             sep_pa_end_year (float): decimal year specifying when to stop plotting orbit
                 tracks in the Sep/PA panels (default: 2025.0).
-            cbar_param (string): options are the following: epochs, sma1, ecc1, inc1, aop1, 
+            cbar_param (string): options are the following: epochs, sma1, ecc1, inc1, aop1,
                 pan1, tau1. Number can be switched out. Default is epochs.
 
         Return:
@@ -364,7 +366,7 @@ class Results(object):
                 'pan': 4,
                 'tau': 5
             }
-            
+
             if cbar_param == 'epochs':
                 pass
             elif cbar_param[0:3] in dict_of_indices:
@@ -376,13 +378,13 @@ class Results(object):
                 index = dict_of_indices[cbar_param[0:3]] + 6*(object_id-1)
             else:
                 raise Exception('Invalid input; acceptable inputs include epochs, sma1, ecc1, inc1, aop1, pan1, tau1, sma2, ecc2, ...')
-            
+
 
             # Split the 2-D post array into series of 1-D arrays for each orbital parameter
             num_objects, remainder = np.divmod(self.post.shape[1],6)
             if object_to_plot > num_objects:
                 return None
-            
+
             sma = self.post[:,dict_of_indices['sma']]
             ecc = self.post[:,dict_of_indices['ecc']]
             inc = self.post[:,dict_of_indices['inc']]
@@ -492,13 +494,13 @@ class Results(object):
             epochs_seppa = np.zeros((num_orbits_to_plot, num_epochs_to_plot))
 
             for i in np.arange(num_orbits_to_plot):
-                
+
                 orb_ind = choose[i]
 
 
                 epochs_seppa[i,:] = np.linspace(
-                    start_mjd, 
-                    Time(sep_pa_end_year, format='decimalyear').mjd, 
+                    start_mjd,
+                    Time(sep_pa_end_year, format='decimalyear').mjd,
                     num_epochs_to_plot
                 )
 

--- a/orbitize/sampler.py
+++ b/orbitize/sampler.py
@@ -137,7 +137,8 @@ class OFTI(Sampler):
         self.results = orbitize.results.Results(
             sampler_name = self.__class__.__name__,
             post = None,
-            lnlike = None
+            lnlike = None,
+            tau_ref_epoch=self.system.tau_ref_epoch
         )
 
     def prepare_samples(self, num_samples):
@@ -318,7 +319,8 @@ class MCMC(Sampler):
         self.results = orbitize.results.Results(
             sampler_name = self.__class__.__name__,
             post = None,
-            lnlike = None
+            lnlike = None,
+            tau_ref_epoch=system.tau_ref_epoch
         )
 
         if self.num_temps > 1:

--- a/orbitize/sampler.py
+++ b/orbitize/sampler.py
@@ -127,7 +127,8 @@ class OFTI(Sampler):
                 self.sep_err[i], self.pa_err[i]
             )
 
-        self.epochs = np.array(self.data_table['epoch'])
+        ### this is OK, ONLY IF we are only using self.epochs for computing RA/Dec from Keplerian elements
+        self.epochs = np.array(self.data_table['epoch']) - self.system.tau_ref_epoch 
 
         # choose scale-and-rotate epoch
         self.epoch_idx = np.argmin(self.sep_err) # epoch with smallest error

--- a/orbitize/system.py
+++ b/orbitize/system.py
@@ -18,8 +18,8 @@ class System(object):
         restrict_angle_ranges (bool, optional): if True, restrict the ranges
             of the position angle of nodes and argument of periastron to [0,180)
             to get rid of symmetric double-peaks for imaging-only datasets.
-        tau_ref_epoch (float, optional): reference epoch for defining tau (MJD). 
-            Default is 60000 (Feb 25, 2023).
+        tau_ref_epoch (float, optional): reference epoch for defining tau (MJD).
+            Default is 58849 (Jan 1, 2020).
         results (list of orbitize.results.Results): results from an orbit-fit
             will be appended to this list as a Results class
 

--- a/orbitize/system.py
+++ b/orbitize/system.py
@@ -42,7 +42,7 @@ class System(object):
     """
     def __init__(self, num_secondary_bodies, data_table, system_mass,
                  plx, mass_err=0, plx_err=0, restrict_angle_ranges=None,
-                 tau_ref_epoch=60000, results=None):
+                 tau_ref_epoch=58849, results=None):
 
         self.num_secondary_bodies = num_secondary_bodies
         self.sys_priors = []

--- a/orbitize/system.py
+++ b/orbitize/system.py
@@ -18,6 +18,8 @@ class System(object):
         restrict_angle_ranges (bool, optional): if True, restrict the ranges
             of the position angle of nodes and argument of periastron to [0,180)
             to get rid of symmetric double-peaks for imaging-only datasets.
+        tau_ref_epoch (float, optional): reference epoch for defining tau (MJD). 
+            Default is 60000 (Feb 25, 2023).
         results (list of orbitize.results.Results): results from an orbit-fit
             will be appended to this list as a Results class
 
@@ -40,12 +42,13 @@ class System(object):
     """
     def __init__(self, num_secondary_bodies, data_table, system_mass,
                  plx, mass_err=0, plx_err=0, restrict_angle_ranges=None,
-                 results=None):
+                 tau_ref_epoch=60000, results=None):
 
         self.num_secondary_bodies = num_secondary_bodies
         self.sys_priors = []
         self.labels = []
         self.results = []
+        self.tau_ref_epoch = tau_ref_epoch
 
         #
         # Group the data in some useful ways
@@ -169,7 +172,7 @@ class System(object):
             mtot = params_arr[-1]
 
             raoff, decoff, vz = kepler.calc_orbit(
-                epochs, sma, ecc, inc, argp, lan, tau, plx, mtot
+                epochs, sma, ecc, inc, argp, lan, tau, plx, mtot, tau_ref_epoch=self.tau_ref_epoch
             )
 
             if len(raoff[self.radec[body_num]]) > 0: # (prevent empty array dimension errors)

--- a/tests/test_conversions.py
+++ b/tests/test_conversions.py
@@ -1,0 +1,57 @@
+"""
+Test the orbitize.basis which converts orbital elements
+"""
+import pytest
+import numpy as np
+import orbitize.basis as basis
+
+def test_tau_t0_conversion():
+    """
+    Test conversion back and forth
+    """
+    tau = 0.1
+    ref_epoch = 51000 # MJD
+    period = 10 # years
+
+    t0 = basis.tau_to_t0(tau, ref_epoch, period)
+    assert t0 == pytest.approx(51000 + 365.25, rel=1e-7)
+
+    tau2 = basis.t0_to_tau(t0, ref_epoch, period)
+    assert tau == pytest.approx(tau2, rel=1e-7)
+
+    t0 = basis.tau_to_t0(tau, ref_epoch, period, after_date=47000)
+    assert t0 == pytest.approx(51000 - 9 * 365.25, rel=1e-7)
+
+    tau3 = basis.t0_to_tau(t0, ref_epoch, period)
+    assert tau == pytest.approx(tau3, rel=1e-7)
+
+def test_tau_t0_conversion_vector():
+    """
+    Make sure it works vectorized.
+    """
+    taus = np.array([0.1, 0.2])
+    ref_epoch = 55000 # MJD
+    period = np.array([1, 0.5]) # years
+
+    t0s = basis.tau_to_t0(taus, ref_epoch, period)
+    for t0 in t0s:
+        assert t0 == pytest.approx(55000 + 365.25/10, rel=1e-7)
+
+def test_switch_tau_basis():
+    """
+    Switch reference epochs
+    """
+    old_taus = np.array([0.5, 0.5])
+    ref_epoch = np.array([50000, 55000])
+    period = np.array([2, 2])
+    new_epoch = np.array([50000 + 365.25, 55000 + 365.25])
+
+    new_taus = basis.switch_tau_epoch(old_taus, ref_epoch, new_epoch, period)
+
+    assert new_taus[0] == pytest.approx(0, rel=1e-7)
+    assert new_taus[1] == pytest.approx(0, rel=1e-7)
+
+if __name__ == "__main__":
+    test_tau_t0_conversion()
+    test_tau_t0_conversion_vector()
+    test_switch_tau_basis()

--- a/tests/test_driver.py
+++ b/tests/test_driver.py
@@ -87,6 +87,23 @@ def test_create_driver_from_table():
                              plx_err=0.1) # parallax error [mas]
     _compare_table(myDriver.system.data_table)
 
+def test_system_kwargs():
+    """
+    Test additional arguments to the system class
+    """
+    testdir = os.path.dirname(os.path.abspath(__file__))
+    input_file = os.path.join(testdir, 'test_val.csv')
+    myDriver = driver.Driver(input_file, # path to data file
+                             'MCMC', # name of algorith for orbit-fitting
+                             1, # number of secondary bodies in system
+                             1.0, # total system mass [M_sun]
+                             50.0, # total parallax of system [mas]
+                             mass_err=0.1, # mass error [M_sun]
+                             plx_err=0.1,
+                             system_kwargs={"tau_ref_epoch": 50000}) # parallax error [mas]
+    assert myDriver.system.tau_ref_epoch == 50000
+
 if __name__ == '__main__':
     test_create_driver_from_filename()
     test_create_driver_from_table()
+    test_system_kwargs()

--- a/tests/test_results.py
+++ b/tests/test_results.py
@@ -51,7 +51,7 @@ def test_init_and_add_samples():
     Returns results.Results object
     """
     # Create object
-    results_obj = results.Results(sampler_name='testing')
+    results_obj = results.Results(sampler_name='testing', tau_ref_epoch=50000)
     # Simulate some sample draws, assign random likelihoods
     n_orbit_draws1 = 1000
     sim_post = simulate_orbit_sampling(n_orbit_draws1)
@@ -68,12 +68,13 @@ def test_init_and_add_samples():
     expected_length = n_orbit_draws1 + n_orbit_draws2
     assert results_obj.post.shape == (expected_length,8)
     assert results_obj.lnlike.shape == (expected_length,)
+    assert results_obj.tau_ref_epoch == 50000
 
     return results_obj
 
 @pytest.fixture()
 def results_to_test():
-    results_obj = results.Results(sampler_name='testing')
+    results_obj = results.Results(sampler_name='testing', tau_ref_epoch=50000)
     # Simulate some sample draws, assign random likelihoods
     n_orbit_draws1 = 1000
     sim_post = simulate_orbit_sampling(n_orbit_draws1)
@@ -121,6 +122,10 @@ def test_save_and_load_results(results_to_test, format='hdf5', has_lnlike=True):
     assert loaded_results.post.shape == (expected_length, 8)
     if has_lnlike:
         assert loaded_results.lnlike.shape == (expected_length,)
+
+    # check tau reference epoch is stored
+    assert loaded_results.tau_ref_epoch == 50000
+
     # Clean up: Remove save file
     os.remove(save_filename)
 


### PR DESCRIPTION
This PR addresses issues #61 and #62. The key changes are

- utilities in manipulate tau (change reference epoch, and get date of periastron) using the basis.py module
- system/driver now can set the tau reference epoch as an init argument
- default reference epoch is Jan 1, 2020 (MJD=58849) instead of the old MJD = 0
- Results class now saves tau reference epoch to the header and can handle the reference epoch internally so user can still pass in MJD dates

This PR modifies the Results and OFTI classes, as well lots of other miscellaneous bits of code, so it would be good to verify I didn't mess up anyone's code. Another open question is whether we want to call it basis.py or something else -- my hope in the future is that if we have different sets of orbital elements, we could include them in this module. 