### PR TITLE
Fix radec/seppa conversion with OFTI sampler

### DIFF
--- a/orbitize/system.py
+++ b/orbitize/system.py
@@ -192,6 +192,34 @@ class System(object):
 
         return model
 
+    def convert_data_table_radec2seppa(self,body_num=1):
+        """
+        Converts rows of self.data_table given in radec to seppa.
+        Note that self.input_table remains unchanged.
+
+        Args:
+            body_num (int): which object to convert (1 = first planet)
+        """
+        for i in self.radec[body_num]: # Loop through rows where input provided in radec
+            # Get ra/dec values
+            ra = self.data_table['quant1'][i]
+            ra_err = self.data_table['quant1_err'][i]
+            dec = self.data_table['quant2'][i]
+            dec_err = self.data_table['quant2_err'][i]
+            # Convert to sep/PA
+            sep, pa = radec2seppa(ra,dec)
+            sep_err, pa_err = radec2seppa(ra_err,dec_err)
+            # Update data_table
+            self.data_table['quant1'][i]=sep
+            self.data_table['quant1_err'][i]=sep_err
+            self.data_table['quant2'][i]=pa
+            self.data_table['quant2_err'][i]=pa_err
+            self.data_table['quant_type'][i]='seppa'
+            # Update self.radec and self.seppa arrays
+            self.radec[body_num]=np.delete(self.radec[body_num],np.where(self.radec[body_num]==i)[0])
+            self.seppa[body_num]=np.append(self.seppa[body_num],i)
+
+
     def add_results(self, results):
         """
         Adds an orbitize.results.Results object to the list in system.results

--- a/orbitize/system.py
+++ b/orbitize/system.py
@@ -55,6 +55,8 @@ class System(object):
         #
 
         self.data_table = data_table
+        # Creates a copy of the input in case data_table needs to be modified
+        self.input_table = self.data_table.copy()
 
         # List of arrays of indices corresponding to each body
         self.body_indices = []

--- a/tests/test_OFTI.py
+++ b/tests/test_OFTI.py
@@ -15,22 +15,22 @@ input_file = os.path.join(testdir, 'GJ504.csv')
 input_file_1epoch = os.path.join(testdir, 'GJ504_1epoch.csv')
 
 def test_scale_and_rotate():
-    
+
     # perform scale-and-rotate
     myDriver = orbitize.driver.Driver(input_file, 'OFTI',
     1, 1.22, 56.95,mass_err=0.08, plx_err=0.26)
-    
+
     s = myDriver.sampler
     samples = s.prepare_samples(100)
 
     sma,ecc,inc,argp,lan,tau,plx,mtot = [samp for samp in samples]
-    
+
     ra, dec, vc = orbitize.kepler.calc_orbit(s.epochs, sma, ecc, inc, argp, lan, tau, plx, mtot)
     sep, pa = orbitize.system.radec2seppa(ra, dec)
     sep_sar, pa_sar = np.median(sep[s.epoch_idx]), np.median(pa[s.epoch_idx])
-    
+
     # test to make sure sep and pa scaled to scale-and-rotate epoch
-    sar_epoch = s.data_table[s.epoch_idx]
+    sar_epoch = s.system.data_table[s.epoch_idx]
     assert sep_sar == pytest.approx(sar_epoch['quant1'], abs=sar_epoch['quant1_err'])
     assert pa_sar == pytest.approx(sar_epoch['quant2'], abs=sar_epoch['quant2_err'])
 
@@ -39,7 +39,7 @@ def test_scale_and_rotate():
 
     # test orbit plot generation
     s.results.plot_orbits(start_mjd=s.epochs[0])
-    
+
     samples = s.results.post
     sma = samples[:,0]
     ecc = samples[:,1]
@@ -53,25 +53,25 @@ def test_scale_and_rotate():
     ra, dec, vc = orbitize.kepler.calc_orbit(s.epochs, sma, ecc, inc, argp, lan, tau, plx, mtot)
     sep, pa = orbitize.system.radec2seppa(ra, dec)
     sep_sar, pa_sar = np.median(sep[s.epoch_idx]), np.median(pa[s.epoch_idx])
-    
+
     # test to make sure sep and pa scaled to scale-and-rotate epoch
     assert sep_sar == pytest.approx(sar_epoch['quant1'], abs=sar_epoch['quant1_err'])
     assert pa_sar == pytest.approx(sar_epoch['quant2'], abs=sar_epoch['quant2_err'])
 
 
 def test_run_sampler():
-    
+
     # initialize sampler
     myDriver = orbitize.driver.Driver(input_file, 'OFTI',
     1, 1.22, 56.95,mass_err=0.08, plx_err=0.26)
-    
+
     s = myDriver.sampler
 
     # change eccentricity prior
     myDriver.system.sys_priors[1] = priors.LinearPrior(-2.18, 2.01)
-    
+
     # test num_samples=1
-    s.run_sampler(0,num_samples=1)    
+    s.run_sampler(0,num_samples=1)
 
     # test to make sure outputs are reasonable
     orbits = s.run_sampler(1000)
@@ -81,29 +81,29 @@ def test_run_sampler():
     sma = np.median([x[idx['sma1']] for x in orbits])
     ecc = np.median([x[idx['ecc1']] for x in orbits])
     inc = np.median([x[idx['inc1']] for x in orbits])
-    
+
     # expected values from Blunt et al. (2017)
     sma_exp = 48.
     ecc_exp = 0.19
     inc_exp = np.radians(140)
-    
+
     # test to make sure OFTI values are within 20% of expectations
     assert sma == pytest.approx(sma_exp, abs=0.2*sma_exp)
     assert ecc == pytest.approx(ecc_exp, abs=0.2*ecc_exp)
     assert inc == pytest.approx(inc_exp, abs=0.2*inc_exp)
-        
+
     # test with only one epoch
     myDriver = orbitize.driver.Driver(input_file_1epoch, 'OFTI',
     1, 1.22, 56.95,mass_err=0.08, plx_err=0.26)
     s = myDriver.sampler
     s.run_sampler(1)
     print()
-    
+
 def test_fixed_sys_params_sampling():
     # test in case of fixed mass and parallax
     myDriver = orbitize.driver.Driver(input_file, 'OFTI',
     1, 1.22, 56.95)
-    
+
     s = myDriver.sampler
     samples = s.prepare_samples(100)
     assert np.all(samples[-1] == s.priors[-1])

--- a/tests/test_system.py
+++ b/tests/test_system.py
@@ -36,5 +36,22 @@ def test_add_and_clear_results():
     test_system.add_results(test_results)
     assert len(test_system.results)==1
 
+def test_convert_data_table_radec2seppa():
+    num_secondary_bodies=1
+    testdir = os.path.dirname(os.path.abspath(__file__))
+    input_file = os.path.join(testdir, 'test_val.csv')
+    data_table=read_input.read_file(input_file)
+    system_mass=1.0
+    plx=10.0
+    mass_err=0.1
+    plx_err=1.0
+    # Initialize System object
+    test_system = system.System(
+        num_secondary_bodies, data_table, system_mass,
+        plx, mass_err=mass_err, plx_err=plx_err
+    )
+    test_system.convert_data_table_radec2seppa()
+
 if __name__ == '__main__':
     test_add_and_clear_results()
+    test_convert_data_table_radec2seppa()


### PR DESCRIPTION
This is a fix for Issue #108 

As discussed, I remove `sampler.data_table` and `sampler.input_table` in favour of `system.data_table` and `system.input_table`. I moved the actual radec/seppa conversion calculation to be done within the `system` object, as I wanted it to change `system.data_table` in place while also updating the arrays `system.radec` and `system.seppa` used to keep track of which entries are in which format. I believe these arrays are necessary in additional to the `quant_type` column of `data_table` because it sorts them by body number. 

Right now, these conversions are done for one body at a time since we don't do multi-planet yet. It seems like the OFTI sampler was already hard-coded for just 1 planet so I kept it that way to keep the scope of this PR only on #108. It can be made to accommodate multiple planets when we make that bigger update!