### PR TITLE
Add random seed to child processes

### DIFF
--- a/orbitize/sampler.py
+++ b/orbitize/sampler.py
@@ -275,6 +275,8 @@ class OFTI(Sampler,):
                                        size: total_orbits
 
         """
+
+        np.random.seed()
          
         n_orbits_saved = 0
         output_orbits = np.empty((total_orbits, len(self.priors)))


### PR DESCRIPTION
@vighnesh-nagpal I found a minor bug in the parallel processing code. A new random seed needs to be generated for each child process, otherwise they will all generate the same orbits. Tough bug to catch. See here for an example: https://stackoverflow.com/questions/9209078/using-python-multiprocessing-with-different-random-seed-for-each-process

Once you approve I can pull this into master 1-2-3!