### PR TITLE
Add a keyword for plotting orbits that cross PA=360

### DIFF
--- a/orbitize/results.py
+++ b/orbitize/results.py
@@ -261,7 +261,7 @@ class Results(object):
                     num_orbits_to_plot=100, num_epochs_to_plot=100,
                     square_plot=True, show_colorbar=True, cmap=cmap,
                     sep_pa_color='lightgrey', sep_pa_end_year=2025.0,
-                    cbar_param='epochs'):
+                    cbar_param='epochs', mod180=False):
 
         """
         Plots one orbital period for a select number of fitted orbits
@@ -285,6 +285,8 @@ class Results(object):
                 tracks in the Sep/PA panels (default: 2025.0).
             cbar_param (string): options are the following: epochs, sma1, ecc1, inc1, aop1,
                 pan1, tau1. Number can be switched out. Default is epochs.
+            mod180 (Bool): if True, PA will be plotted in range [180, 540]. Useful for plotting short
+                arcs with PAs that cross 360 deg during observations (default: False)
 
         Return:
             ``matplotlib.pyplot.Figure``: the orbit plot if input is valid, ``None`` otherwise
@@ -452,7 +454,7 @@ class Results(object):
                 plot_epochs = np.where(yr_epochs <= sep_pa_end_year)[0]
                 yr_epochs = yr_epochs[plot_epochs]
 
-                seps, pas = orbitize.system.radec2seppa(raoff[i,:], deoff[i,:])
+                seps, pas = orbitize.system.radec2seppa(raoff[i,:], deoff[i,:], mod180=mod180)
 
                 plt.sca(ax1)
                 plt.plot(yr_epochs, seps, color=sep_pa_color)

--- a/orbitize/system.py
+++ b/orbitize/system.py
@@ -256,7 +256,7 @@ class System(object):
         """
         self.results = []
 
-def radec2seppa(ra, dec):
+def radec2seppa(ra, dec, mod180=False):
     """
     Convenience function for converting from
     right ascension/declination to separation/
@@ -265,6 +265,11 @@ def radec2seppa(ra, dec):
     Args:
         ra (np.array of float): array of RA values, in mas
         dec (np.array of float): array of Dec values, in mas
+        mod180 (Bool): if True, output PA values will be given
+            in range [180, 540] (useful for plotting short
+            arcs with PAs that cross 360 during observations)
+            (default: False)
+
 
     Returns:
         tulple of float: (separation [mas], position angle [deg])
@@ -272,5 +277,8 @@ def radec2seppa(ra, dec):
     """
     sep = np.sqrt((ra**2) + (dec**2))
     pa = np.degrees(np.arctan2(ra, dec)) % 360.
+
+    if mod180:
+        pa[pa < 180] += 360
 
     return sep, pa

--- a/orbitize/system.py
+++ b/orbitize/system.py
@@ -266,7 +266,7 @@ def radec2seppa(ra, dec, mod180=False):
         ra (np.array of float): array of RA values, in mas
         dec (np.array of float): array of Dec values, in mas
         mod180 (Bool): if True, output PA values will be given
-            in range [180, 540] (useful for plotting short
+            in range [180, 540) (useful for plotting short
             arcs with PAs that cross 360 during observations)
             (default: False)
 

--- a/tests/test_system.py
+++ b/tests/test_system.py
@@ -1,11 +1,13 @@
 """
 Tests functionality of methods in system.py
 """
+import numpy as np
+import pytest
+import os
 
 import orbitize.read_input as read_input
 import orbitize.system as system
 import orbitize.results as results
-import os
 
 def test_add_and_clear_results():
     num_secondary_bodies=1
@@ -52,6 +54,25 @@ def test_convert_data_table_radec2seppa():
     )
     test_system.convert_data_table_radec2seppa()
 
+def test_radec2seppa():
+
+    ras = np.array([-1, -1, 1, 1])
+    decs = np.array([-1, 1, -1, 1])
+
+    pas_expected = np.array([225., 315., 135., 45.])
+    pas_expected_180mod = np.array([225., 315., 495., 405.])
+    seps_expected = np.ones(4)*np.sqrt(2)
+
+    sep_nomod, pa_nomod = system.radec2seppa(ras, decs)
+    sep_180mod, pa_180mod = system.radec2seppa(ras, decs, mod180=True)
+
+    assert sep_nomod ==  pytest.approx(seps_expected, abs=1e-3)
+    assert sep_180mod ==  pytest.approx(seps_expected, abs=1e-3)
+    assert pa_nomod ==  pytest.approx(pas_expected, abs=1e-3)
+    assert pa_180mod ==  pytest.approx(pas_expected_180mod, abs=1e-3)
+
+
 if __name__ == '__main__':
     test_add_and_clear_results()
     test_convert_data_table_radec2seppa()
+    test_radec2seppa()


### PR DESCRIPTION
Go from this:

<img width="585" alt="Screen Shot 2019-10-18 at 10 40 13 AM" src="https://user-images.githubusercontent.com/20113975/67115768-c76ff300-f193-11e9-80e6-5b76b618a7d6.png">

to this:

<img width="530" alt="Screen Shot 2019-10-18 at 10 37 51 AM" src="https://user-images.githubusercontent.com/20113975/67115782-cdfe6a80-f193-11e9-9952-970d12860760.png">


I left this as a keyword for the user to choose because for some orbits I think folks will want to show the 0/360 jumps. It just looks bad for short arcs.