### PR TITLE
Plot RA with positive to the left as is convention

### DIFF
--- a/orbitize/results.py
+++ b/orbitize/results.py
@@ -419,6 +419,7 @@ class Results(object):
             ax.set_ylabel('$\Delta$Dec [mas]')
             ax.locator_params(axis='x', nbins=6)
             ax.locator_params(axis='y', nbins=6)
+            ax.invert_xaxis() # To go to a left-handed coordinate system
 
             # add colorbar
             if show_colorbar:

--- a/orbitize/results.py
+++ b/orbitize/results.py
@@ -24,7 +24,7 @@ import orbitize.system
 cmap = mpl.cm.Purples_r
 cmap = colors.LinearSegmentedColormap.from_list(
     'trunc({n},{a:.2f},{b:.2f})'.format(n=cmap.name, a=0.0, b=0.7),
-    cmap(np.linspace(0.0, 0.7, 1000.))
+    cmap(np.linspace(0.0, 0.7, 1000))
 )
 
 class Results(object):


### PR DESCRIPTION
I just noticed that the orbit plots have RA in the wrong direction. Positive RA should go to the left, not the right. I added one line of code to invert the x-axis. I edited this online, so definitely wait for the tests to pass first to make sure I didn't make any typos.