### PR TITLE
Explicitly convert input table into masked table

### DIFF
--- a/orbitize/read_input.py
+++ b/orbitize/read_input.py
@@ -7,6 +7,8 @@ import numpy as np
 import orbitize
 from astropy.table import Table
 from astropy.io.ascii import read, write
+from packaging import version
+from astropy import __version__ as astropyversion
 
 def read_file(filename):
     """ Reads data from any file for use in orbitize
@@ -86,6 +88,10 @@ def read_file(filename):
     # read file
     try:
         input_table = read(filename)
+
+        # convert to masked table if astropy version >= 4.0
+        if version.parse(astropyversion) >= version.parse("4.0") and input_table.has_masked_columns:
+            input_table = Table(input_table, masked=True, copy=False)
     except:
         raise Exception('Unable to read file: {}. \n Please check file path and format.'.format(filename))
     num_measurements = len(input_table)

--- a/orbitize/results.py
+++ b/orbitize/results.py
@@ -24,7 +24,7 @@ import orbitize.system
 cmap = mpl.cm.Purples_r
 cmap = colors.LinearSegmentedColormap.from_list(
     'trunc({n},{a:.2f},{b:.2f})'.format(n=cmap.name, a=0.0, b=0.7),
-    cmap(np.linspace(0.0, 0.7, 1000.))
+    cmap(np.linspace(0.0, 0.7, 1000))
 )
 
 class Results(object):


### PR DESCRIPTION
Fixes #152. Checks astropy version and if it's >= 4.0 it explicitly converts the table into a masked table. Also fixes the numpy issue.