### PR TITLE
fix bug that was causing corner to fail on loaded results objs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -115,3 +115,5 @@ build.sh
 *.fits
 *.png
 !docs/orbitize_logo_500.png
+.vscode/settings.json
+tests/test_results.h5

--- a/orbitize/results.py
+++ b/orbitize/results.py
@@ -146,7 +146,7 @@ class Results(object):
             # probably a old results file when reference epoch was fixed at MJD = 0
             tau_ref_epoch = 0
         try:
-            labels = np.array([hf.attrs['parameter_labels']])
+            labels = hf.attrs['parameter_labels']
         except KeyError:
             # again, probably an old file without saved parameter labels
             labels = ['sma1', 'ecc1', 'inc1', 'aop1', 'pan1', 'tau1', 'plx', 'mtot']

--- a/tests/test_results.py
+++ b/tests/test_results.py
@@ -129,7 +129,7 @@ def test_save_and_load_results(results_to_test, has_lnlike=True):
     original_length = results_to_save.post.shape[0]
     expected_length = original_length * 2
     assert loaded_results.post.shape == (expected_length, 8)
-    assert loaded_results.labels[0].tolist() == std_labels
+    assert loaded_results.labels.tolist() == std_labels
     if has_lnlike:
         assert loaded_results.lnlike.shape == (expected_length,)
 


### PR DESCRIPTION
Small bugfix for a minor issue I believe was introduced in the RV PR. `Results.labels` was being loaded into a 2d array rather than a list, which was causing corner plots to fail. Easy fix!