### PR TITLE
Update results.py

### DIFF
--- a/orbitize/results.py
+++ b/orbitize/results.py
@@ -254,7 +254,7 @@ class Results(object):
             'sig': '$\\sigma$ [m/s]',
             'mtot': '$M_T$ [M$_\\odot$]',
             'm0': '$M_0$ [M$_\\odot$]',
-            'm': '$M_{0}$ [M$_\{Jup\}$]',
+            'm': '$M_{0}$ [M$_\{{Jup\}}$]',
         }
 
         if param_list is None:


### PR DESCRIPTION
Fixed a small bug in results.py. On line 257, in plot_corner, changed '$M_{0}$ [M$_\{Jup\}$]' to '$M_{0}$ [M$_\{{Jup\}}$]'. The bug leads to a KeyError if the user wants to make a corner plot and plot the covariances of any secondary masses.