### PR TITLE
Remove redundant code

### DIFF
--- a/orbitize/results.py
+++ b/orbitize/results.py
@@ -532,8 +532,6 @@ class Results(object):
                     deoff[i, :] = deoff0
 
                 yr_epochs = Time(epochs_seppa[i, :], format='mjd').decimalyear
-                plot_epochs = np.where(yr_epochs <= sep_pa_end_year)[0]
-                yr_epochs = yr_epochs[plot_epochs]
 
                 seps, pas = orbitize.system.radec2seppa(raoff[i, :], deoff[i, :], mod180=mod180)
 


### PR DESCRIPTION
Hello,
Me and my team(@Khadir991 and @Slimane-ABDENNOUR) thought that the lines `535, 536` on `orbitize/main` 
```
                yr_epochs = Time(epochs_seppa[i, :], format='mjd').decimalyear
                plot_epochs = np.where(yr_epochs <= sep_pa_end_year)[0] # < ----
                yr_epochs = yr_epochs[plot_epochs] 			# < ----
```

were redundant.

As `epochs_seppa[i, :]` are generated with `np.linspace` :

```
                epochs_seppa[i, :] = np.linspace(
                    start_mjd,
                    Time(sep_pa_end_year, format='decimalyear').mjd,
                    num_epochs_to_plot
                )
```
And in the `orbitize/main` `start_mjd` is guaranteed to be smaller than `sep_pa_end_year`, 
the `np.where` conditions should be met for the full array everytime. 
And if the condition is not met (by at least one element of the array) an error would occur (similar to the one in [Codeastro's broken_orbitize activity](https://github.com/semaphoreP/codeastro/tree/main/Day2)).

We thought that removing those two lines would slightly improve the runtime of the plot_orbits().

Kind regards.
