### PR TITLE
Add FAQ section with tau docs.

### DIFF
--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -1,0 +1,21 @@
+.. _faq:
+
+Frequently Asked Questions
+==========================
+
+Here are some questions we get often. Please suggest more by raising an 
+issue in the `Github Issue Tracker <https://github.com/sblunt/orbitize/issues>`_.
+
+**What is τ and how is it related to epoch of periastron?**
+
+We use τ to define the epoch of periastron as we do not know when periastron will be for many of our directly
+imaged planets. A detailed description of how τ is related to other quantities such as :math:`t_p` is available:
+
+.. toctree::
+   :maxdepth: 1
+
+   faq/Time_Of_Periastron.ipynb
+
+
+
+

--- a/docs/faq/Time_Of_Periastron.ipynb
+++ b/docs/faq/Time_Of_Periastron.ipynb
@@ -57,7 +57,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 1,
    "metadata": {},
    "outputs": [
     {
@@ -81,17 +81,17 @@
     "tau_ref_epoch = 58849\n",
     "\n",
     "# convert tau to tp\n",
-    "tp = orbitize.basis.tau_to_t0(tau, tau_ref_epoch, period)\n",
+    "tp = orbitize.basis.tau_to_tp(tau, tau_ref_epoch, period)\n",
     "\n",
     "print(tp)\n",
     "\n",
     "# convert tp back to tau\n",
-    "tau2 = orbitize.basis.t0_to_tau(tp, tau_ref_epoch, period)\n",
+    "tau2 = orbitize.basis.tp_to_tau(tp, tau_ref_epoch, period)\n",
     "\n",
     "print(tau2)\n",
     "\n",
     "# convert tau to tp, but pick the first tp after MJD = 0\n",
-    "tp_new = orbitize.basis.tau_to_t0(tau, tau_ref_epoch, period, after_date=0)\n",
+    "tp_new = orbitize.basis.tau_to_tp(tau, tau_ref_epoch, period, after_date=0)\n",
     "\n",
     "print(tp_new)"
    ]
@@ -109,7 +109,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [
     {
@@ -134,13 +134,6 @@
     "\n",
     "print(M_peri)"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ]
 }

--- a/docs/faq/Time_Of_Periastron.ipynb
+++ b/docs/faq/Time_Of_Periastron.ipynb
@@ -1,0 +1,146 @@
+{
+ "metadata": {
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.5-final"
+  },
+  "orig_nbformat": 2,
+  "kernelspec": {
+   "name": "python3",
+   "display_name": "Python 3",
+   "language": "python"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2,
+ "cells": [
+  {
+   "source": [
+    "# τ and Time of Periastron\n",
+    "\n",
+    "Here, we will discuss what exactly is τ, the parameter `orbitize!` uses to parametrize the epoch of periastron, and how it is related to other quantities of the epoch of periastron in the literuatre. \n",
+    "\n",
+    "## Time of Periastron and Motivation for τ\n",
+    "\n",
+    "The time (or epoch) of periastron is an important quantity for describing an orbit. It defines when the two orbiting bodies are closest to one another (i.e., when a planet is closest to its star). In many papers in the literature, the epoch of periastron is described by $t_p$, which is literally a date at which periastron occurs. This is a very important date because we use this date to anchor our orbit in time. \n",
+    "\n",
+    "The value of $t_p$ is well constrained when we know we observed periastron, which is often the case for radial velociy or transiting exoplanets when the orbital periods are short and our data covers a full orbital period. In those cases, we know approximately when $t_p$ should be in time, so it is easy to define prior bounds for it. However, in the case of direct imaging, many of our companions have orbital periods that are orders of magnitude larger than the current orbital coverage of the data where we do not really know if the next periastron is in years, decades, centuries, or even millennia. This is the motivation for τ. \n",
+    "\n",
+    "## Definition of τ\n",
+    "\n",
+    "τ is a dimentionless quantity between 0 and 1 defined with respect to a reference epoch $t_{ref}$. For a planet that has a $t_p$ and an orbital period (P), then we define τ as:\n",
+    "\n",
+    "$$\n",
+    "\\tau = \\frac{t_p - t_{ref}}{P}.\n",
+    "$$\n",
+    "\n",
+    "Because τ is always between 0 and 1, it is easy to figure out the bounds of τ whereas if the orbital period is highly uncertain, it may be difficult to put bounds on $t_p$ that would encompass all allowable bound orbits. \n",
+    "\n",
+    "## Relation to $t_p$\n",
+    "\n",
+    "As seen in the above equation, it is relatively straightforward to covert between orbital parameter sets that use τ and $t_p$. You just need to know the orbital period and reference epoch. In `orbitize!`, both the `System` class and the `Results` class has the attribute `tau_ref_epoch` which stores $t_{ref}$, so there should always be a convenient way to grab this number. By default, we use $t_{ref} = 58849$ MJD. \n",
+    "\n",
+    "One thing to note that is a given orbit has only a single valid τ, but that an orbit can be defined by many $t_p$, since the orbit is periodic. Thus, $t_p + P$ is another valid time of periastron. \n",
+    "\n",
+    "We also provide some helper functions to covert between $t_p$ and τ"
+   ],
+   "cell_type": "markdown",
+   "metadata": {}
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": [
+      "60649.50097715886\n0.2000000000000002\n6634.471662393138\n"
+     ]
+    }
+   ],
+   "source": [
+    "import numpy as np\n",
+    "import orbitize.basis\n",
+    "\n",
+    "# How to get orbital period in the orbitize! standard basis\n",
+    "sma = 9 # au, semi-major axis\n",
+    "mtot = 1.2 # Solar masses, total mass\n",
+    "period = np.sqrt(sma**3/mtot) # years, period\n",
+    "\n",
+    "tau = 0.2\n",
+    "tau_ref_epoch = 58849\n",
+    "\n",
+    "# convert tau to tp\n",
+    "tp = orbitize.basis.tau_to_t0(tau, tau_ref_epoch, period)\n",
+    "\n",
+    "print(tp)\n",
+    "\n",
+    "# convert tp back to tau\n",
+    "tau2 = orbitize.basis.t0_to_tau(tp, tau_ref_epoch, period)\n",
+    "\n",
+    "print(tau2)\n",
+    "\n",
+    "# convert tau to tp, but pick the first tp after MJD = 0\n",
+    "tp_new = orbitize.basis.tau_to_t0(tau, tau_ref_epoch, period, after_date=0)\n",
+    "\n",
+    "print(tp_new)"
+   ]
+  },
+  {
+   "source": [
+    "## Relation to Mean Anomaly\n",
+    "\n",
+    "The mean anomaly (M) of an orbit describes the current orbital phase of a planet. M goes from 0 to 2π, and M = 0 means the planet is at periastron. Unlike $t_p$ and τ which describe the epoch of periastron, M describes the current position of the planet in its orbit. \n",
+    "\n",
+    "To compute M of a planet at some time t, we have provided the following helper function:"
+   ],
+   "cell_type": "markdown",
+   "metadata": {}
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": [
+      "5.829874251150844\n1.3951473992034527e-15\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Use the orbit defined in the previous example\n",
+    "\n",
+    "t = 60000 # time in MJD when we want to know the M of the particle\n",
+    "\n",
+    "M = orbitize.basis.tau_to_manom(t, sma, mtot, tau, tau_ref_epoch)\n",
+    "\n",
+    "print(M)\n",
+    "\n",
+    "# now compute M for periastron\n",
+    "M_peri = orbitize.basis.tau_to_manom(tp, sma, mtot, tau, tau_ref_epoch)\n",
+    "\n",
+    "print(M_peri)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ]
+}

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -46,6 +46,7 @@ User Guide:
 
    installation
    tutorials
+   faq
    api
 
 Contributing:

--- a/orbitize/basis.py
+++ b/orbitize/basis.py
@@ -1,45 +1,61 @@
 import numpy as np
 import astropy.units as u
 
+import warnings # remove when functions are depreciated
+
 def tau_to_t0(tau, ref_epoch, period, after_date=None):
     """
+    DEPRECATING!! Repalced by tau_to_tp
+    """
+    warnings.warn('DEPRECATION: tau_to_t0 is being deprecated in the next orbitize! release. Please use tau_to_tp instead!', FutureWarning)
+    return tau_to_tp(tau, ref_epoch, period, after_date=after_date)
+
+def t0_to_tau(tp, ref_epoch, period):
+    """
+    DEPRECATING!! Repalced by tp_to_tau
+    """
+    warnings.warn('DEPRECATION: t0_to_tau is being deprecated in the next orbitize! release. Please use t0_to_tau instead!', FutureWarning)
+    return tp_to_tau(tp, ref_epoch, period)
+
+def tau_to_tp(tau, ref_epoch, period, after_date=None):
+    """
     Convert tau (epoch of periastron in fractional orbital period after ref epoch) to
-    T0 (date in days, usually MJD, but works with whatever system ref_epoch is given in)
+    t_p (date in days, usually MJD, but works with whatever system ref_epoch is given in)
 
     Args:
         tau (float or np.array): value of tau to convert
         ref_epoch (float or np.array): date (in days, typically MJD) that tau is defined relative to
         period (float or np.array): period (in years) that tau is noralized with
-        after_date (float): T0 will be the first periastron after this date. If None, use ref_epoch.
+        after_date (float): tp will be the first periastron after this date. If None, use ref_epoch.
 
     Returns:
-        t0 (float or np.array): corresponding T0 of the taus
+        tp (float or np.array): corresponding t_p of the taus
     """
     period_days = period * u.year.to(u.day)
 
-    t0 = tau * (period_days) + ref_epoch
+    tp = tau * (period_days) + ref_epoch
 
     if after_date is not None:
-        num_periods = (after_date - t0)/period_days
+        num_periods = (after_date - tp)/period_days
         num_periods = int(np.ceil(num_periods))
         
-        t0 += num_periods * period_days
+        tp += num_periods * period_days
 
-    return t0
+    return tp
 
-def t0_to_tau(t0, ref_epoch, period):
+def tp_to_tau(tp, ref_epoch, period):
     """
-    Convert T0 to tau
+    Convert t_p to tau
 
     Args:
-        t0 (float or np.array): value to T0 to convert (days, typically MJD)
-        ref_epoch (float or np.array): reference epoch (in days) that tau is defined from. Same system as t0 (e.g., MJD)
+        tp (float or np.array): value to t_p to convert (days, typically MJD)
+        ref_epoch (float or np.array): reference epoch (in days) that tau is defined from. Same system as tp (e.g., MJD)
         period (float or np.array): period (in years) that tau is defined by
 
     Returns:
         tau (float or np.array): corresponding taus
     """
-    tau = (t0 - ref_epoch)/(period * u.year.to(u.day))
+    tau = (tp - ref_epoch)/(period * u.year.to(u.day))
     tau %= 1
 
     return tau
@@ -59,8 +75,8 @@ def switch_tau_epoch(old_tau, old_epoch, new_epoch, period):
     """
     period_days = period * u.year.to(u.day)
 
-    t0 = tau_to_t0(old_tau, old_epoch, period)
-    new_tau = t0_to_tau(t0, new_epoch, period)
+    tp = tau_to_tp(old_tau, old_epoch, period)
+    new_tau = tp_to_tau(tp, new_epoch, period)
 
     return new_tau
 

--- a/orbitize/radvel_utils/compute_sep.py
+++ b/orbitize/radvel_utils/compute_sep.py
@@ -4,7 +4,7 @@ from astropy import units as u
 
 from radvel.basis import Basis
 from radvel.utils import Msini
-from orbitize.basis import t0_to_tau
+from orbitize.basis import tp_to_tau
 from orbitize.kepler import calc_orbit
 
 def compute_sep(
@@ -69,7 +69,7 @@ def compute_sep(
     parallax = np.random.normal(plx, plx_err, size = chain_len)
     lan = np.random.random_sample(size = chain_len) * 2. * np.pi
     tp_mjd = df['tp{}'.format(pl_num)].values - 2400000.5
-    tau = t0_to_tau(tp_mjd, tau_ref_epoch, period_yr)
+    tau = tp_to_tau(tp_mjd, tau_ref_epoch, period_yr)
 
     # compute projected separation in mas
     raoff, deoff, _ = calc_orbit(

--- a/tests/test_conversions.py
+++ b/tests/test_conversions.py
@@ -5,7 +5,7 @@ import pytest
 import numpy as np
 import orbitize.basis as basis
 
-def test_tau_t0_conversion():
+def test_tau_tp_conversion():
     """
     Test conversion back and forth
     """
@@ -13,19 +13,19 @@ def test_tau_t0_conversion():
     ref_epoch = 51000 # MJD
     period = 10 # years
 
-    t0 = basis.tau_to_t0(tau, ref_epoch, period)
-    assert t0 == pytest.approx(51000 + 365.25, rel=1e-7)
+    tp = basis.tau_to_tp(tau, ref_epoch, period)
+    assert tp == pytest.approx(51000 + 365.25, rel=1e-7)
 
-    tau2 = basis.t0_to_tau(t0, ref_epoch, period)
+    tau2 = basis.tp_to_tau(tp, ref_epoch, period)
     assert tau == pytest.approx(tau2, rel=1e-7)
 
-    t0 = basis.tau_to_t0(tau, ref_epoch, period, after_date=47000)
-    assert t0 == pytest.approx(51000 - 9 * 365.25, rel=1e-7)
+    tp = basis.tau_to_tp(tau, ref_epoch, period, after_date=47000)
+    assert tp == pytest.approx(51000 - 9 * 365.25, rel=1e-7)
 
-    tau3 = basis.t0_to_tau(t0, ref_epoch, period)
+    tau3 = basis.tp_to_tau(tp, ref_epoch, period)
     assert tau == pytest.approx(tau3, rel=1e-7)
 
-def test_tau_t0_conversion_vector():
+def test_tau_tp_conversion_vector():
     """
     Make sure it works vectorized.
     """
@@ -33,9 +33,9 @@ def test_tau_t0_conversion_vector():
     ref_epoch = 55000 # MJD
     period = np.array([1, 0.5]) # years
 
-    t0s = basis.tau_to_t0(taus, ref_epoch, period)
-    for t0 in t0s:
-        assert t0 == pytest.approx(55000 + 365.25/10, rel=1e-7)
+    tps = basis.tau_to_tp(taus, ref_epoch, period)
+    for tp in tps:
+        assert tp == pytest.approx(55000 + 365.25/10, rel=1e-7)
 
 def test_switch_tau_basis():
     """
@@ -52,6 +52,6 @@ def test_switch_tau_basis():
     assert new_taus[1] == pytest.approx(0, rel=1e-7)
 
 if __name__ == "__main__":
-    test_tau_t0_conversion()
-    test_tau_t0_conversion_vector()
+    test_tau_tp_conversion()
+    test_tau_tp_conversion_vector()
     test_switch_tau_basis()


### PR DESCRIPTION
New FAQ section of docs, with a new notebook on tau/tp/M. 

One question, I realized tp is named inconsistently. In `orbitize.basis`, it is referred to as t0. Do we have a preferred notation? 