### PR TITLE
Save load

### DIFF
--- a/orbitize/results.py
+++ b/orbitize/results.py
@@ -42,6 +42,8 @@ class Results(object):
         tau_ref_epoch (float): date (in days, typically MJD) that tau is defined relative to
         labels (list of str): parameter labels in same order as `post`
         num_secondary_bodies (int): number of companions fit 
+        curr_pos (np.array of float): for MCMC only. A multi-D array of the current walker positions
+            that is used for restarting a MCMC sampler. 
 
     The ``post`` array is in the following order::
 
@@ -58,7 +60,7 @@ class Results(object):
     """
 
     def __init__(self, sampler_name=None, post=None, lnlike=None, tau_ref_epoch=None, labels=None,
-                 num_secondary_bodies=None):
+                 num_secondary_bodies=None, curr_pos=None):
 
         self.sampler_name = sampler_name
         self.post = post
@@ -66,8 +68,9 @@ class Results(object):
         self.tau_ref_epoch = tau_ref_epoch
         self.labels = labels
         self.num_secondary_bodies=num_secondary_bodies
+        self.curr_pos = curr_pos
 
-    def add_samples(self, orbital_params, lnlikes, labels):
+    def add_samples(self, orbital_params, lnlikes, labels, curr_pos=None):
         """
         Add accepted orbits and their likelihoods to the results
 
@@ -75,6 +78,7 @@ class Results(object):
             orbital_params (np.array): add sets of orbital params (could be multiple) to results
             lnlike (np.array): add corresponding lnlike values to results
             labels (list of str): list of parameter labels specifying the order in ``orbital_params``
+            curr_pos (np.array of float): for MCMC only. A multi-D array of the current walker positions
 
         Written: Henry Ngo, 2018
         """
@@ -87,6 +91,9 @@ class Results(object):
         else:
             self.post = np.vstack((self.post, orbital_params))
             self.lnlike = np.append(self.lnlike, lnlikes)
+
+        if curr_pos is not None:
+            self.curr_pos = curr_pos
 
     def _set_sampler_name(self, sampler_name):
         """
@@ -122,6 +129,8 @@ class Results(object):
         hf.attrs['parameter_labels'] = self.labels  # Rob: added this to account for the RV labels
         if self.num_secondary_bodies is not None:
             hf.attrs['num_secondary_bodies'] = self.num_secondary_bodies
+        if self.curr_pos is not None:
+            hf.create_dataset("curr_pos", data=self.curr_pos)
 
         hf.close()  # Closes file object, which writes file to disk
 
@@ -162,8 +171,16 @@ class Results(object):
         except KeyError:
             # old, has to be single planet fit
             num_secondary_bodies = 1
+        try:
+            curr_pos = np.array(hf.get('curr_pos'))
+        except KeyError:
+            curr_pos = None
 
         hf.close()  # Closes file object
+
+        # doesn't matter if append or not. Overwrite curr_pos if not None
+        if curr_pos is not None:
+            self.curr_pos = curr_pos
 
         # Adds loaded data to object as per append keyword
         if append:

--- a/orbitize/sampler.py
+++ b/orbitize/sampler.py
@@ -616,7 +616,40 @@ class MCMC(Sampler):
 
         return super(MCMC, self)._logl(full_params) + logp
 
-    def run_sampler(self, total_orbits, burn_steps=0, thin=1, examine_chains=False):
+    def _update_chains_from_sampler(self, sampler, num_steps=None):
+        """
+        Updates self.post, self.chain, and self.lnlike from the MCMC sampler
+
+        Args:
+            sampler (emcee.EnsembleSampler or ptemcee.Sampler): sampler object.
+            num_steps (int): if not None, only stores the first num_steps number of steps
+        """
+        if num_steps is None:
+            # use all the steps, grab total number of steps from dimension of chains
+            num_steps = sampler.chain.shape[-2]
+
+        self.chain = sampler.chain
+        num_params = self.chain.shape[-1]
+
+        if self.use_pt:
+            # chain is shape: Ntemp x Nwalkers x Nsteps x Nparams
+            self.post = sampler.chain[0, :, :num_steps].reshape(-1, num_params) # the reshaping flattens the chain
+            # should also be picking out the lowest temperature logps
+            self.lnlikes = sampler.loglikelihood[0, :, :num_steps].flatten()
+            self.lnlikes_alltemps = sampler.loglikelihood[:, :, :num_steps]
+        else:
+            # chain is shape: Nwalkers x Nsteps x Nparams
+            self.post = sampler.chain[:, :num_steps].reshape(-1, num_params)
+            self.lnlikes = sampler.flatlnprobability[:, :num_steps]
+
+            # convert posterior probability (returned by sampler objects) to likelihood (required by orbitize.results.Results)
+            for i, orb in enumerate(self.post):
+                self.lnlikes[i] -= orbitize.priors.all_lnpriors(orb, self.priors)
+
+        # include fixed parameters in posterior
+        self.post = self._fill_in_fixed_params(self.post)
+
+    def run_sampler(self, total_orbits, burn_steps=0, thin=1, examine_chains=False, output_filename=None, periodic_save_freq=None):
         """
         Runs PT MCMC sampler. Results are stored in ``self.chain`` and ``self.lnlikes``.
         Results also added to ``orbitize.results.Results`` object (``self.results``)
@@ -634,10 +667,22 @@ class MCMC(Sampler):
                 by to remove correlations in the walker steps
             examine_chains (boolean): Displays plots of walkers at each step by
                 running `examine_chains` after `total_orbits` sampled.
+            output_filename (str): Optional filepath for where results file can be saved.
+            periodic_save_freq (int): Optionally, save the current results into ``output_filename``
+                every nth step while running, where n is value passed into this variable. 
 
         Returns:
             ``emcee.sampler`` object: the sampler used to run the MCMC
         """
+
+        if periodic_save_freq is not None and output_filename is None:
+            raise ValueError("output_filename must be defined for periodic saving of the chains")
+        if periodic_save_freq is not None and not isinstance(periodic_save_freq, int):
+            raise TypeError("periodic_save_freq must be an integer")
+        
+        nsteps = int(np.ceil(total_orbits / self.num_walkers))
+        if nsteps <= 0:
+            raise ValueError("Total_orbits must be greater than num_walkers.")
 
         if self.use_pt:
             sampler = ptemcee.Sampler(
@@ -654,52 +699,79 @@ class MCMC(Sampler):
                 kwargs={'include_logp': True}
             )
                 
-        
-        for state in sampler.sample(self.curr_pos, iterations=burn_steps, thin=thin):
+        print("Starting Burn in")
+        for i, state in enumerate(sampler.sample(self.curr_pos, iterations=burn_steps, thin=thin)):
             if self.use_pt:
                 self.curr_pos = state[0]
             else:
                 self.curr_pos = state.coords
+
+            if (i+1) % 5 == 0:
+                print(str(i+1)+'/'+str(burn_steps)+' steps of burn-in complete', end='\r')
+
+            if periodic_save_freq is not None:
+                if (i+1) % periodic_save_freq == 0: # we've completed i+1 steps
+                    self.results.curr_pos = self.curr_pos
+                    self.results.save_results(output_filename)
 
         sampler.reset()
-        print('Burn in complete')
+        print('')
+        print('Burn in complete. Sampling posterior now.')
 
-        nsteps = int(np.ceil(total_orbits / self.num_walkers))
-
-        assert (nsteps > 0), 'Total_orbits must be greater than num_walkers.'
-
-        i=0
-        for state in sampler.sample(self.curr_pos, iterations=nsteps, thin=thin):
+        saved_upto = 0 # keep track of how many steps of this chain we've saved. this is the next index that needs to be saved 
+        for i, state in enumerate(sampler.sample(self.curr_pos, iterations=nsteps, thin=thin)):
             if self.use_pt:
                 self.curr_pos = state[0]
             else:
                 self.curr_pos = state.coords
-            i+=1
+                
             # print progress statement
-            if i % 5 == 0:
-                print(str(i)+'/'+str(nsteps)+' steps completed', end='\r')
+            if (i+1) % 5 == 0:
+                print(str(i+1)+'/'+str(nsteps)+' steps completed', end='\r')
+
+            if periodic_save_freq is not None:
+                if (i+1) % periodic_save_freq == 0: # we've completed i+1 steps
+                    self._update_chains_from_sampler(sampler, num_steps=i+1)
+
+                    # figure out what is the new chunk of the chain and corresponding lnlikes that have been computed before last save
+                    # grab the current posterior and lnlikes and reshape them to have the Nwalkers x Nsteps dimension again
+                    post_shape = self.post.shape
+                    curr_chain_shape = (self.num_walkers, post_shape[0]//self.num_walkers, post_shape[-1])
+                    curr_chain = self.post.reshape(curr_chain_shape)
+                    curr_lnlike_chain = self.lnlikes.reshape(curr_chain_shape[:2])
+                    # use the reshaped arrays and find the new steps we computed
+                    curr_chunk = curr_chain[:, saved_upto:i+1]
+                    curr_chunk = curr_chunk.reshape(-1, curr_chunk.shape[-1]) # flatten nwalkers x nsteps dim
+                    curr_lnlike_chunk = curr_lnlike_chain[:, saved_upto:i+1].flatten()
+
+                    # add this current chunk to the results object (which already has all the previous chunks saved)
+                    self.results.add_samples(curr_chunk, curr_lnlike_chunk, 
+                                                labels=self.system.labels, curr_pos=self.curr_pos)
+                    self.results.save_results(output_filename)
+                    saved_upto = i+1
+
         print('')
+        self._update_chains_from_sampler(sampler)
 
-        # TODO: Need something here to pick out temperatures, just using lowest one for now
-        self.chain = sampler.chain
+        if periodic_save_freq is None:
+            # need to save everything
+            self.results.add_samples(self.post, self.lnlikes, labels=self.system.labels, curr_pos=self.curr_pos)
+        elif saved_upto < nsteps:
+            # just need to save the last few
+            # same code as above except we just need to grab the last few
+            post_shape = self.post.shape
+            curr_chain_shape = (self.num_walkers, post_shape[0]//self.num_walkers, post_shape[-1])
+            curr_chain = self.post.reshape(curr_chain_shape)
+            curr_lnlike_chain = self.lnlikes.reshape(curr_chain_shape[:2])
+            curr_chunk = curr_chain[:, saved_upto:]
+            curr_chunk = curr_chunk.reshape(-1, curr_chunk.shape[-1]) # flatten nwalkers x nsteps dim
+            curr_lnlike_chunk = curr_lnlike_chain[:, saved_upto:].flatten()
 
-        if self.use_pt:
-            self.post = sampler.flatchain[0, :, :]
-            # should also be picking out the lowest temperature logps
-            self.lnlikes = sampler.loglikelihood[0, :, :].flatten()
-            self.lnlikes_alltemps = sampler.loglikelihood
-        else:
-            self.post = sampler.flatchain
-            self.lnlikes = sampler.flatlnprobability
+            self.results.add_samples(curr_chunk, curr_lnlike_chunk, 
+                                                labels=self.system.labels, curr_pos=self.curr_pos)
 
-            # convert posterior probability (returned by sampler objects) to likelihood (required by orbitize.results.Results)
-            for i, orb in enumerate(self.post):
-                self.lnlikes[i] -= orbitize.priors.all_lnpriors(orb, self.priors)
-
-        # include fixed parameters in posterior
-        self.post = self._fill_in_fixed_params(self.post)
-
-        self.results.add_samples(self.post, self.lnlikes, labels=self.system.labels)
+        if output_filename is not None:
+            self.results.save_results(output_filename)
 
         print('Run complete')
 

--- a/tests/test_mcmc.py
+++ b/tests/test_mcmc.py
@@ -57,8 +57,8 @@ def test_mcmc_runs(num_temps=0, num_threads=1):
     assert myDriver.sampler.results.post.shape[0] == 1500 
 
     # run it a little more testing that everything gets saved even if prediodic_save_freq is not a multiple of the number of steps
-    output_filename = os.path.join(orbitize.DATADIR, 'test_mcmc.hdf5')
-    myDriver.sampler.run_sampler(500, burn_steps=1, output_filename=output_filename, periodic_save_freq=3)
+    output_filename_2 = os.path.join(orbitize.DATADIR, 'test_mcmc_v1.hdf5')
+    myDriver.sampler.run_sampler(500, burn_steps=1, output_filename=output_filename_2, periodic_save_freq=3)
     assert myDriver.sampler.results.post.shape[0] == 2000 
 
     # test that lnlikes being saved are correct
@@ -66,6 +66,14 @@ def test_mcmc_runs(num_temps=0, num_threads=1):
     computed_lnlike_test = myDriver.sampler._logl(myDriver.sampler.results.post[0])
 
     assert returned_lnlike_test == pytest.approx(computed_lnlike_test, abs=0.01)
+
+    # test resuming and restarting from a prevous save
+    new_sampler = sampler.MCMC(myDriver.system, num_temps=num_temps, num_walkers=n_walkers, 
+                                num_threads=num_threads, prev_result_filename=output_filename)
+    assert new_sampler.results.post.shape[0] == 1500
+    new_sampler.run_sampler(500, burn_steps=1)
+    assert new_sampler.results.post.shape[0] == 2000
+    assert new_sampler.results.post[0,0] == myDriver.sampler.results.post[0,0]
 
 
 def test_examine_chop_chains(num_temps=0, num_threads=1):

--- a/tests/test_mcmc.py
+++ b/tests/test_mcmc.py
@@ -1,11 +1,13 @@
 import pytest
 
 import os
+import numpy as np
 import orbitize
 from orbitize.driver import Driver
 import orbitize.sampler as sampler
 import orbitize.system as system
 import orbitize.read_input as read_input
+import orbitize.results as results
 import matplotlib.pyplot as plt
 
 
@@ -34,12 +36,30 @@ def test_mcmc_runs(num_temps=0, num_threads=1):
 
     # run it a little (tests 0 burn-in steps)
     myDriver.sampler.run_sampler(100)
+    assert myDriver.sampler.results.post.shape[0] == 100
 
     # run it a little more
     myDriver.sampler.run_sampler(1000, burn_steps=1)
+    assert myDriver.sampler.results.post.shape[0] == 1100
 
-    # run it a little more (tests adding to results object)
-    myDriver.sampler.run_sampler(1000, burn_steps=1)
+    # run it a little more (tests adding to results object, and periodic saving)
+    output_filename = os.path.join(orbitize.DATADIR, 'test_mcmc.hdf5')
+    myDriver.sampler.run_sampler(400, burn_steps=1, output_filename=output_filename, periodic_save_freq=2)
+
+    # test results object exists and has 2100*100 steps
+    assert os.path.exists(output_filename)
+    saved_results = results.Results()
+    saved_results.load_results(output_filename)
+    assert saved_results.post.shape[0] == 1500 
+    assert saved_results.curr_pos is not None # current positions should be saved
+    assert np.all(saved_results.curr_pos == myDriver.sampler.curr_pos)
+    # also check it is consistent with the internal results object in myDriver
+    assert myDriver.sampler.results.post.shape[0] == 1500 
+
+    # run it a little more testing that everything gets saved even if prediodic_save_freq is not a multiple of the number of steps
+    output_filename = os.path.join(orbitize.DATADIR, 'test_mcmc.hdf5')
+    myDriver.sampler.run_sampler(500, burn_steps=1, output_filename=output_filename, periodic_save_freq=3)
+    assert myDriver.sampler.results.post.shape[0] == 2000 
 
     # test that lnlikes being saved are correct
     returned_lnlike_test = myDriver.sampler.results.lnlike[0]


### PR DESCRIPTION
Addresses #104. MCMC Sampler can now periodically save new steps to orbitize.results which saves to HDF5 file. Can also create a sampler that resumes from a previous file. 