### PR TITLE
Correct typo on documentation page

### DIFF
--- a/docs/faq/Time_Of_Periastron.ipynb
+++ b/docs/faq/Time_Of_Periastron.ipynb
@@ -26,7 +26,7 @@
    "source": [
     "# τ and Time of Periastron\n",
     "\n",
-    "Here, we will discuss what exactly is τ, the parameter `orbitize!` uses to parametrize the epoch of periastron, and how it is related to other quantities of the epoch of periastron in the literuatre. \n",
+    "Here, we will discuss what exactly is τ, the parameter `orbitize!` uses to parametrize the epoch of periastron, and how it is related to other quantities of the epoch of periastron in the literature. \n",
     "\n",
     "## Time of Periastron and Motivation for τ\n",
     "\n",


### PR DESCRIPTION
This is a very minor typo correction to change "literuatre" to "literature".
Thanks for the great documentation!