### PR TITLE
fix #234. Also another possible bug.

### DIFF
--- a/orbitize/results.py
+++ b/orbitize/results.py
@@ -316,7 +316,7 @@ class Results(object):
             index_num = np.where(np.array(self.labels) == param)[0][0]
 
             # only plot non-fixed parameters
-            if np.std(self.post[:, i]) > 0:
+            if np.std(self.post[:, index_num]) > 0:
                 param_indices.append(index_num)
                 label_key = param
                 if label_key.startswith('aop') or label_key.startswith('pan') or label_key.startswith('inc'):
@@ -325,9 +325,9 @@ class Results(object):
                     secondary_mass_indices.append(i)
 
 
-        samples = copy.copy(self.post[:, param_indices])  # keep only chains for selected parameters
+        samples = np.copy(self.post[:, param_indices])  # keep only chains for selected parameters
         samples[:, angle_indices] = np.degrees(
-            self.post[:, angle_indices])  # convert angles from rad to deg
+            samples[:, angle_indices])  # convert angles from rad to deg
         samples[:, secondary_mass_indices] *= u.solMass.to(u.jupiterMass) # convert to Jupiter masses for companions
 
         if 'labels' not in corner_kwargs:  # use default labels if user didn't already supply them


### PR DESCRIPTION
Addresses issue #234 (see plots below). Also I noticed that line 319 should be ` if np.std(self.post[:, index_num]) > 0:` because `i` indexes into the `param_list` array, not `self.post`. 

Reproducing the issue #234, now behavior is good:

```
corner_figure_median_95 = result_copy.plot_corner(
	param_list = ['sma1', 'ecc1', 'inc1', 'aop1', 'pan1', 'tau1'],
	show_titles = True
)
```
![image](https://user-images.githubusercontent.com/2245740/122465933-84b87c80-cf6d-11eb-852e-60723ea22a41.png)

```
corner_figure_median_95 = result_copy.plot_corner(
	param_list = ['tau1','sma1','pan1','aop1','ecc1','inc1'],
	show_titles = True
)
```

![image](https://user-images.githubusercontent.com/2245740/122465991-9437c580-cf6d-11eb-8a71-da4d83d10cab.png)

