### PR TITLE
use astropy tables in results to address #256

### DIFF
--- a/orbitize/results.py
+++ b/orbitize/results.py
@@ -8,6 +8,7 @@ import astropy.units as u
 import astropy.constants as consts
 from astropy.io import fits
 from astropy.time import Time
+import astropy.table as table
 from erfa import ErfaWarning
 
 import matplotlib as mpl
@@ -183,8 +184,8 @@ class Results(object):
             version_number = "<= 1.13"
         post = np.array(hf.get('post'))
         lnlike = np.array(hf.get('lnlike'))
-        data=np.array(hf.get('data'))
-        self.data=data
+        data = np.array(hf.get('data'))
+        self.data = table.Table(data) # turn back into astropy table, also keeps str formatted right
 
         # get the tau reference epoch
         try:

--- a/tests/test_results.py
+++ b/tests/test_results.py
@@ -153,6 +153,10 @@ def test_save_and_load_results(results_to_test, has_lnlike=True):
     # check tau reference epoch is stored
     assert loaded_results.tau_ref_epoch == 50000
 
+    # check that str fields are indeed strs
+    # checking just one str entry probably is good enough
+    assert isinstance(loaded_results.data['quant_type'][0], str)
+
     # Clean up: Remove save file
     os.remove(save_filename)
 


### PR DESCRIPTION
The text fields in results.data should now be str and not bytes. Addresses #256, and possibly also @252. 