### PR TITLE
address #248

### DIFF
--- a/orbitize/system.py
+++ b/orbitize/system.py
@@ -119,7 +119,7 @@ class System(object):
         # we should track the influence of the planet(s) on each other/the star if we are not fitting massless planets and 
         # we are not fitting relative astrometry of just a single body
         self.track_planet_perturbs = self.fit_secondary_mass and \
-                                     ((len(self.radec[1]) + len(self.seppa[1]) + len(self.rv[1]) < len(data_table)) or \
+                                     ((len(self.radec[1]) + len(self.seppa[1]) + len(self.rv[0]) < len(data_table)) or \
                                       (self.num_secondary_bodies > 1))
 
         if self.hipparcos_IAD is not None:

--- a/orbitize/system.py
+++ b/orbitize/system.py
@@ -116,11 +116,17 @@ class System(object):
                 np.intersect1d(self.body_indices[body_num], rv_indices)
             )
 
-        # we should track the influence of the planet(s) on each other/the star if we are not fitting massless planets and 
-        # we are not fitting relative astrometry of just a single body
-        self.track_planet_perturbs = self.fit_secondary_mass and \
-                                     ((len(self.radec[1]) + len(self.seppa[1]) + len(self.rv[0]) < len(data_table)) or \
-                                      (self.num_secondary_bodies > 1))
+        # we should track the influence of the planet(s) on each other/the star if:
+        # we are not fitting massless planets and 
+        # we have more than 1 companion OR we have stellar astrometry
+        self.track_planet_perturbs = (
+            self.fit_secondary_mass and 
+            (
+                (len(self.radec[0]) + len(self.seppa[0] > 0) or
+                (self.num_secondary_bodies > 1)
+                )
+            )
+        )
 
         if self.hipparcos_IAD is not None:
             self.track_planet_perturbs = True
@@ -284,8 +290,6 @@ class System(object):
         if self.track_planet_perturbs:
             masses = np.zeros((self.num_secondary_bodies + 1, n_orbits))
             mtots = np.zeros((self.num_secondary_bodies + 1, n_orbits))
-
-        total_rv0 = 0
 
         if comp_rebound or self.use_rebound:
                 


### PR DESCRIPTION
We should set track_planet_perturbs to True if the user wants to fit for a dynamical mass AND

1. there is data other than relative astrometry and ** stellar ** RVs (i.e. absolute astrometry of the primary)
2. there is more than one secondary body