### PR TITLE
Updated deprecated numpy functions

### DIFF
--- a/orbitize/plot.py
+++ b/orbitize/plot.py
@@ -201,6 +201,14 @@ def plot_orbits(results, object_to_plot=1, start_mjd=51544.,
     if object_to_plot == 0:
         raise ValueError("Plotting the primary's orbit is currently unsupported. Stay tuned.")
 
+    if rv_time_series and 'm0' not in results.labels:
+        rv_time_series = False
+
+        warnings.warn("It seems that the stellar and companion mass "
+                      "have not been fitted separately. Setting "
+                      "rv_time_series=True is therefore not possible "
+                      "so the argument is set to False instead.")
+
     with warnings.catch_warnings():
         warnings.simplefilter('ignore', ErfaWarning)
 

--- a/orbitize/read_input.py
+++ b/orbitize/read_input.py
@@ -234,7 +234,7 @@ def read_file(filename):
     for index, row in enumerate(input_table):
         # First check if epoch is a number
         try:
-            float_epoch = np.float(row['epoch'])
+            float_epoch = np.float64(row['epoch'])
         except:
             raise Exception(
                 'Problem reading epoch in the input file. Epoch should be given in MJD.')

--- a/orbitize/results.py
+++ b/orbitize/results.py
@@ -146,9 +146,9 @@ class Results(object):
 
         hf = h5py.File(filename, 'r')  # Opens file for reading
         # Load up each dataset from hdf5 file
-        sampler_name = np.str(hf.attrs['sampler_name'])
+        sampler_name = str(hf.attrs['sampler_name'])
         try:
-            version_number = np.str(hf.attrs['version_number'])
+            version_number = str(hf.attrs['version_number'])
         except KeyError:
             version_number = "<= 1.13"
         post = np.array(hf.get('post'))
@@ -226,7 +226,7 @@ class Results(object):
             gaia = None
 
         try:
-            fitting_basis = np.str(hf.attrs['fitting_basis'])
+            fitting_basis = str(hf.attrs['fitting_basis'])
         except KeyError:
             # if key does not exist, then it was fit in the standard basis
             fitting_basis = 'Standard'

--- a/orbitize/sampler.py
+++ b/orbitize/sampler.py
@@ -972,7 +972,7 @@ class MCMC(Sampler):
         # Get the flattened chain from Results object (nwalkers*nsteps, nparams)
         flatchain = np.copy(self.results.post)
         total_samples, n_params = flatchain.shape
-        n_steps = np.int(total_samples/self.num_walkers)
+        n_steps = int(total_samples/self.num_walkers)
         # Reshape it to (nwalkers, nsteps, nparams)
         chn = flatchain.reshape((self.num_walkers, n_steps, n_params))
 
@@ -1028,7 +1028,7 @@ class MCMC(Sampler):
         # Retrieve information from results object
         flatchain = np.copy(self.results.post)
         total_samples, n_params = flatchain.shape
-        n_steps = np.int(total_samples/self.num_walkers)
+        n_steps = int(total_samples/self.num_walkers)
         flatlnlikes = np.copy(self.results.lnlike)
 
         # Reshape chain to (nwalkers, nsteps, nparams)


### PR DESCRIPTION
This is a minor PR that fixes the issue related to several deprecated `numpy` functions (in version 1.24) for certain data types (see issues #330 and #329).

I have updated the use of `np.float`, `np.int`, and `np.str`. This fix should also work with `numpy` versions older than 1.24.

Not related, but I also added a warning in `plot_orbits` related to the `rv_time_series` parameter, just for convenience.

Let me know in case you have any feedback 😊