### PR TITLE
fix orbitize tests

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ astropy>=4
 numpy
 scipy
 emcee>=3
-ptemcee
+ptemcee @ git+https://github.com/sblunt/ptemcee@main
 matplotlib
 corner
 h5py

--- a/tests/test_priors.py
+++ b/tests/test_priors.py
@@ -31,7 +31,7 @@ lnprob_inputs = {
 }
 
 expected_probs = {
-	priors.GaussianPrior : np.array([0., 0., nm(1000.,1.).pdf(1000.), nm(1000.,1.).pdf(999.)]),
+	priors.GaussianPrior : np.array([0., 0., nm(1000.,1.).pdf(1000.)* np.sqrt(2*np.pi), nm(1000.,1.).pdf(999.)* np.sqrt(2*np.pi)]),
 	priors.LogUniformPrior : np.array([0., 0., 1., 2./3., 0.5, 0.])/np.log(2),
 	priors.UniformPrior : np.array([1., 1., 1., 0., 0.]),
 	priors.SinPrior : np.array([0., 0.5, 0., 0., 0.]),
@@ -66,7 +66,7 @@ def test_compute_lnprob():
 
 		lnprobs = TestPrior.compute_lnprob(values2test)
 
-		assert np.log(expected_probs[Prior]) == pytest.approx(lnprobs, abs=threshold)
+		assert np.log(expected_probs[Prior])  == pytest.approx(lnprobs, abs=threshold)
 
 
 if __name__=='__main__':

--- a/tests/test_rebound.py
+++ b/tests/test_rebound.py
@@ -22,8 +22,8 @@ inc = np.array([0.47123, 0.47123, 0.47123, 0.47123])
 aop = np.array([1.91986, 0.29670, 1.16937, 1.5184])
 pan = np.array([1.18682, 1.18682, 1.18682, 1.18682])
 tau = np.array([0.71, 0.79, 0.50, 0.54])
-plx = np.array([7])
-mtot = np.array([1.49])
+plx = 7
+mtot = 1.49
 tau_ref_epoch = 0
 years = 365.25*5
 


### PR DESCRIPTION
The truth values have an extra 1/sqrt(2pi) that we aren't accounting for. I multiplied it to the truth values and the test should pass now. 