### PR TITLE
Replace depricated calculate_com function

### DIFF
--- a/.github/workflows/run-notebooks.yml
+++ b/.github/workflows/run-notebooks.yml
@@ -32,5 +32,5 @@ jobs:
         python -m pip install . --no-build-isolation
     - name: Run tutorial notebooks
       run: |
-        py.test --nbmake docs/tutorials/*.ipynb
+        py.test --nbmake --nbmake-timeout=3000 docs/tutorials/*.ipynb
       

--- a/orbitize/nbody.py
+++ b/orbitize/nbody.py
@@ -83,7 +83,7 @@ def calc_orbit(
         for j,t in enumerate(te):
             sim.integrate(t/365.25)
             #for the star and each planet in each epoch denoted by j,t find the RA, Dec, and RV
-            com = sim.calculate_com()
+            com = sim.com()
             ra_reb[j,0] = -(ps[0].x-com.x)# ra is negative x
             dec_reb[j,0] = ps[0].y-com.y
             vz[j,0] = ps[0].vz


### PR DESCRIPTION
it looks like the latest version of REBOUND no longer has the `calculate_com()` function and this causes our tests to fail. Replacing with the `com()` function. 