### PR TITLE
Nested sampling with MultiNest

### DIFF
--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -27,10 +27,10 @@ imaged planets. A detailed description of how τ is related to other quantities 
 
 Our goal with the default prior is to have an isotropic distribution of the orbital plane.
 To obtain this, we use inclination and position angle of the ascending node (PAN) to
-define the orbital plane. They actually coorespond to the two angles in a spherical coordinate system:
-inclinaion is the polar angle and PAN is the azimuthal angle. Becuase of this choice of coordinates,
+define the orbital plane. They actually correspond to the two angles in a spherical coordinate system:
+inclination is the polar angle and PAN is the azimuthal angle. Because of this choice of coordinates,
 there are less orbital configurations near the poles (when inclination is near 0 or 180), so we use
-a sine prior to downweigh those areas to give us an isotropic distribution. 
+a sine prior to downweight those areas to give us an isotropic distribution. 
 A more detailed discussion of this is here:
 
 .. toctree::

--- a/orbitize/driver.py
+++ b/orbitize/driver.py
@@ -16,7 +16,9 @@ class Driver(object):
         input_data: Either a relative path to data file or astropy.table.Table object
             in the orbitize format. See ``orbitize.read_input``
         sampler_str (str): algorithm to use for orbit computation. "MCMC" for
-            Markov Chain Monte Carlo, "OFTI" for Orbits for the Impatient
+            Markov Chain Monte Carlo, "OFTI" for Orbits for the Impatient,
+            "NestedSampler" for nested sampling with Dynesty, or "MultiNest"
+            for nested sampling with (Py)MultiNest.
         num_secondary_bodies (int): number of secondary bodies in the system.
             Should be at least 1.
         stellar_or_system_mass (float): mass of the primary star (if fitting for

--- a/orbitize/plot.py
+++ b/orbitize/plot.py
@@ -107,23 +107,21 @@ def plot_corner(results, param_list=None, **corner_kwargs):
     param_indices = []
     angle_indices = []
     secondary_mass_indices = []
-    fixed_indices = []
-    for i, label_key in enumerate(param_list):
-        index_num = results.param_idx[label_key]
+    for i, param in enumerate(param_list):
+        index_num = results.param_idx[param]
 
         # only plot non-fixed parameters
-        if not np.isclose(0.0, np.std(results.post[:, index_num])):
+        if np.std(results.post[:, index_num]) > 0:
             param_indices.append(index_num)
+            label_key = param
             if (
                 label_key.startswith("aop")
                 or label_key.startswith("pan")
                 or label_key.startswith("inc")
             ):
-                angle_indices.append(i-len(fixed_indices))
+                angle_indices.append(i)
             if label_key.startswith("m") and label_key != "m0" and label_key != "mtot":
-                secondary_mass_indices.append(i-len(fixed_indices))
-        else:
-            fixed_indices.append(i)
+                secondary_mass_indices.append(i)
 
     samples = np.copy(
         results.post[:, param_indices]
@@ -139,7 +137,7 @@ def plot_corner(results, param_list=None, **corner_kwargs):
         "labels" not in corner_kwargs
     ):  # use default labels if user didn't already supply them
         reduced_labels_list = []
-        for i in param_indices:
+        for i in np.arange(len(param_indices)):
             label_key = param_list[i]
             if label_key.startswith("m") and label_key != "m0" and label_key != "mtot":
                 body_num = label_key[1]

--- a/orbitize/plot.py
+++ b/orbitize/plot.py
@@ -107,21 +107,23 @@ def plot_corner(results, param_list=None, **corner_kwargs):
     param_indices = []
     angle_indices = []
     secondary_mass_indices = []
-    for i, param in enumerate(param_list):
-        index_num = results.param_idx[param]
+    fixed_indices = []
+    for i, label_key in enumerate(param_list):
+        index_num = results.param_idx[label_key]
 
         # only plot non-fixed parameters
         if np.std(results.post[:, index_num]) > 0:
             param_indices.append(index_num)
-            label_key = param
             if (
                 label_key.startswith("aop")
                 or label_key.startswith("pan")
                 or label_key.startswith("inc")
             ):
-                angle_indices.append(i)
+                angle_indices.append(i-len(fixed_indices))
             if label_key.startswith("m") and label_key != "m0" and label_key != "mtot":
-                secondary_mass_indices.append(i)
+                secondary_mass_indices.append(i-len(fixed_indices))
+        else:
+            fixed_indices.append(i)
 
     samples = np.copy(
         results.post[:, param_indices]
@@ -137,7 +139,7 @@ def plot_corner(results, param_list=None, **corner_kwargs):
         "labels" not in corner_kwargs
     ):  # use default labels if user didn't already supply them
         reduced_labels_list = []
-        for i in np.arange(len(param_indices)):
+        for i in param_indices:
             label_key = param_list[i]
             if label_key.startswith("m") and label_key != "m0" and label_key != "mtot":
                 body_num = label_key[1]

--- a/orbitize/plot.py
+++ b/orbitize/plot.py
@@ -112,7 +112,7 @@ def plot_corner(results, param_list=None, **corner_kwargs):
         index_num = results.param_idx[label_key]
 
         # only plot non-fixed parameters
-        if np.std(results.post[:, index_num]) > 0:
+        if not np.isclose(0.0, np.std(results.post[:, index_num])):
             param_indices.append(index_num)
             if (
                 label_key.startswith("aop")

--- a/orbitize/results.py
+++ b/orbitize/results.py
@@ -272,6 +272,12 @@ class Results(object):
         self.param_idx = self.system.param_idx
         self.standard_param_idx = self.basis.standard_basis_idx
 
+        if 'ln_evidence' in hf.attrs:
+            self.ln_evidence = hf.attrs['ln_evidence']
+
+        if 'ln_evidence_err' in hf.attrs:
+            self.ln_evidence_err = hf.attrs['ln_evidence_err']
+
         try:
             curr_pos = np.array(hf.get('curr_pos'))
         except KeyError:

--- a/orbitize/results.py
+++ b/orbitize/results.py
@@ -45,6 +45,8 @@ class Results(object):
         self.lnlike = lnlike
         self.curr_pos = curr_pos
         self.version_number = version_number
+        self.ln_evidence = None
+        self.ln_evidence_err = None
 
         if self.system is not None:
             self.tau_ref_epoch = self.system.tau_ref_epoch
@@ -114,6 +116,12 @@ class Results(object):
         hf.attrs['sampler_name'] = self.sampler_name
         hf.attrs['version_number'] = self.version_number
 
+        if self.ln_evidence is not None:
+            hf.attrs['ln_evidence'] = self.ln_evidence
+
+        if self.ln_evidence_err is not None:
+            hf.attrs['ln_evidence_err'] = self.ln_evidence_err
+
         # Now add post and lnlike from the results object as datasets
         hf.create_dataset('post', data=self.post)
         # hf.create_dataset('data', data=self.data)
@@ -147,19 +155,18 @@ class Results(object):
         hf = h5py.File(filename, 'r')  # Opens file for reading
         # Load up each dataset from hdf5 file
         sampler_name = str(hf.attrs['sampler_name'])
-        try:
+        if 'version_number' in hf.attrs:
             version_number = str(hf.attrs['version_number'])
-        except KeyError:
+        else:
             version_number = "<= 1.13"
         post = np.array(hf.get('post'))
         lnlike = np.array(hf.get('lnlike'))
 
-
-        try:
+        if 'num_secondary_bodies' in hf.attrs:
             num_secondary_bodies = int(hf.attrs['num_secondary_bodies'])
-        except KeyError:
+        else:
             # old, has to be single planet fit
-            num_secondary_bodies = 1  
+            num_secondary_bodies = 1
 
         try:
             data_table = table.Table(np.array(hf.get('data')))

--- a/orbitize/sampler.py
+++ b/orbitize/sampler.py
@@ -12,7 +12,6 @@ import numpy as np
 import ptemcee
 
 from astropy.time import Time
-from pymultinest.analyse import Analyzer
 
 import orbitize.kepler
 import orbitize.lnlike

--- a/orbitize/sampler.py
+++ b/orbitize/sampler.py
@@ -1637,6 +1637,7 @@ class MultiNest(Sampler):
             mpi_rank = 0
 
         if hdf5_file is not None and mpi_rank == 0:
-            self.results.save_results(output_file=hdf5_file)
+            # Only a single process should write to the HDF5 file
+            self.results.save_results(filename=hdf5_file)
 
         return post_samples[:, :-1]

--- a/orbitize/sampler.py
+++ b/orbitize/sampler.py
@@ -1,26 +1,23 @@
-import numpy as np
-import astropy.units as u
-import astropy.constants as consts
 import abc
+import multiprocessing as mp
 import time
 import warnings
-from astropy.time import Time
 
+import astropy.units as u
+import astropy.constants as consts
 import dynesty
-
 import emcee
+import matplotlib.pyplot as plt
+import numpy as np
 import ptemcee
-import multiprocessing as mp
 
-from multiprocessing import Pool
+from astropy.time import Time
+from pymultinest.analyse import Analyzer
 
+import orbitize.kepler
 import orbitize.lnlike
 import orbitize.priors
-import orbitize.kepler
-from orbitize import cuda_ext
-
 import orbitize.results
-import matplotlib.pyplot as plt
 
 
 class Sampler(abc.ABC):
@@ -997,7 +994,7 @@ class MCMC(Sampler):
         if nsteps <= 0:
             raise ValueError("Total_orbits must be greater than num_walkers.")
 
-        with Pool(processes=self.num_threads) as pool:
+        with mp.Pool(processes=self.num_threads) as pool:
             if self.use_pt:
                 sampler = ptemcee.Sampler(
                     self.num_walkers,
@@ -1654,7 +1651,10 @@ class MultiNest(Sampler):
         )
 
         analyzer = pymultinest.analyse.Analyzer(
-            n_parameters, outputfiles_basename=output_basename)
+            n_parameters,
+            outputfiles_basename=output_basename,
+            verbose=False,
+        )
 
         sampling_stats = analyzer.get_stats()
         post_samples = analyzer.get_equal_weighted_posterior()

--- a/orbitize/sampler.py
+++ b/orbitize/sampler.py
@@ -1636,7 +1636,7 @@ class MultiNest(Sampler):
         except ModuleNotFoundError:
             mpi_rank = 0
 
-        if save_results is not None and mpi_rank == 0:
+        if hdf5_file is not None and mpi_rank == 0:
             self.results.save_results(output_file=hdf5_file)
 
         return post_samples[:, :-1]

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,3 +16,4 @@ sphinx
 docutils<0.17
 rebound
 dynesty
+pymultinest

--- a/tests/test_nested_sampler.py
+++ b/tests/test_nested_sampler.py
@@ -51,12 +51,7 @@ def test_nested_sampler():
     dynamic_eccentricities = mysampler.results.post[:, lab["ecc1"]]
     assert np.median(dynamic_eccentricities) == pytest.approx(ecc, abs=0.1)
 
-<<<<<<< HEAD
-    _ = mysampler.run_sampler(bound="multi", static=True, num_threads=8, run_nested_kwargs={})
-=======
-
-    _ = mysampler.run_sampler(bound="multi", static=True, start_method=start_method, num_threads=8)
->>>>>>> main
+    _ = mysampler.run_sampler(bound="multi", static=True, start_method=start_method, num_threads=8, run_nested_kwargs={})
     print("Finished second run!")
 
     static_eccentricities = mysampler.results.post[:, lab["ecc1"]]

--- a/tests/test_nested_sampler.py
+++ b/tests/test_nested_sampler.py
@@ -1,5 +1,5 @@
 """
-Tests the NestedSampler class by fixing all parameters except for eccentricity.
+Tests the NestedSampler and MultiNest classes by fixing all parameters except for eccentricity.
 """
 
 from orbitize import system, sampler
@@ -40,25 +40,56 @@ def test_nested_sampler():
 
     # run both static & dynamic nested samplers
     mysampler = sampler.NestedSampler(sys)
-    _ = mysampler.run_sampler(bound="multi", pfrac=0.95, static=False, num_threads=8)
+    _ = mysampler.run_sampler(bound="multi", pfrac=0.95, static=False, num_threads=8, run_nested_kwargs={})
     print("Finished first run!")
 
     dynamic_eccentricities = mysampler.results.post[:, lab["ecc1"]]
     assert np.median(dynamic_eccentricities) == pytest.approx(ecc, abs=0.1)
 
-    _ = mysampler.run_sampler(bound="multi", static=True, num_threads=8)
+    _ = mysampler.run_sampler(bound="multi", static=True, num_threads=8, run_nested_kwargs={})
     print("Finished second run!")
 
     static_eccentricities = mysampler.results.post[:, lab["ecc1"]]
     assert np.median(static_eccentricities) == pytest.approx(ecc, abs=0.1)
 
-    # check that the static sampler raises an error when user tries to set pfrac
-    # for static sampler
-    try:
-        mysampler.run_sampler(pfrac=0.1, static=True)
-    except ValueError:
-        pass
+
+def test_multinest():
+    # generate data
+    mtot = 1.2  # total system mass [M_sol]
+    plx = 60.0  # parallax [mas]
+    orbit_frac = 95
+    data_table, sma = generate_synthetic_data(
+        orbit_frac,
+        mtot,
+        plx,
+        num_obs=30,
+    )
+
+    # assumed ecc value
+    ecc = 0.5
+
+    # initialize orbitize `System` object
+    sys = system.System(1, data_table, mtot, plx)
+    lab = sys.param_idx
+
+    ecc = 0.5  # eccentricity
+
+    # set all parameters except eccentricity to fixed values (same as used to generate data)
+    sys.sys_priors[lab["inc1"]] = np.pi / 4
+    sys.sys_priors[lab["sma1"]] = sma
+    sys.sys_priors[lab["aop1"]] = np.pi / 4
+    sys.sys_priors[lab["pan1"]] = np.pi / 4
+    sys.sys_priors[lab["tau1"]] = 0.8
+    sys.sys_priors[lab["plx"]] = plx
+    sys.sys_priors[lab["mtot"]] = mtot
+
+    # running the actual sampler is not possible without compiling MultiNest
+    mysampler = sampler.MultiNest(sys)
+    assert hasattr(mysampler, "run_sampler")
+    assert hasattr(mysampler, "results")
+    assert hasattr(mysampler, "system")
 
 
 if __name__ == "__main__":
     test_nested_sampler()
+    test_multinest()


### PR DESCRIPTION
This PR adds the `MultiNest` class to the `sampler` module. MultiNest supports the use of MPI, so it can be executed as e.g. `mpirun -n 100 python run_orbitize.py` if 100 CPUs are available.

Also made some minor modifications in `NestedSampler` that uses Dynesty. I added the `nlive` parameter, which is used by the static sampler. I removed a `ValueError`, which seemed not needed since `pfrac` is not used when `static=True`.

The unit tests do not actually call `run_sampler`, since MultiNest needs to be manually installed.

Let me know if you have any comments/feedback!