### PR TITLE
Actually use pool in ptemcee

### DIFF
--- a/orbitize/sampler.py
+++ b/orbitize/sampler.py
@@ -993,8 +993,7 @@ class MCMC(Sampler):
         if nsteps <= 0:
             raise ValueError("Total_orbits must be greater than num_walkers.")
 
-        with mp.Pool(processes=self.num_threads) as pool:
-            if self.use_pt:
+        if self.use_pt:
                 sampler = ptemcee.Sampler(
                     self.num_walkers,
                     self.num_params,
@@ -1006,7 +1005,8 @@ class MCMC(Sampler):
                         self.priors,
                     ],
                 )
-            else:
+        else:
+            with mp.Pool(processes=self.num_threads) as pool:
                 sampler = emcee.EnsembleSampler(
                     self.num_walkers,
                     self.num_params,
@@ -1014,7 +1014,7 @@ class MCMC(Sampler):
                     pool=pool,
                     kwargs={"include_logp": True},
                 )
-
+        
             print("Starting Burn in")
             for i, state in enumerate(
                 sampler.sample(self.curr_pos, iterations=burn_steps, thin=thin)

--- a/orbitize/sampler.py
+++ b/orbitize/sampler.py
@@ -993,7 +993,8 @@ class MCMC(Sampler):
         if nsteps <= 0:
             raise ValueError("Total_orbits must be greater than num_walkers.")
 
-        if self.use_pt:
+        with mp.Pool(processes=self.num_threads) as pool:
+            if self.use_pt:
                 sampler = ptemcee.Sampler(
                     self.num_walkers,
                     self.num_params,
@@ -1005,8 +1006,7 @@ class MCMC(Sampler):
                         self.priors,
                     ],
                 )
-        else:
-            with mp.Pool(processes=self.num_threads) as pool:
+            else:
                 sampler = emcee.EnsembleSampler(
                     self.num_walkers,
                     self.num_params,
@@ -1014,7 +1014,7 @@ class MCMC(Sampler):
                     pool=pool,
                     kwargs={"include_logp": True},
                 )
-        
+
             print("Starting Burn in")
             for i, state in enumerate(
                 sampler.sample(self.curr_pos, iterations=burn_steps, thin=thin)

--- a/orbitize/sampler.py
+++ b/orbitize/sampler.py
@@ -1001,10 +1001,10 @@ class MCMC(Sampler):
                     self._logl,
                     orbitize.priors.all_lnpriors,
                     ntemps=self.num_temps,
-                    threads=self.num_threads,
                     logpargs=[
                         self.priors,
                     ],
+                    pool=pool
                 )
             else:
                 sampler = emcee.EnsembleSampler(
@@ -1118,7 +1118,7 @@ class MCMC(Sampler):
                 self.results.save_results(output_filename)
 
             print("Run complete")
-        # Close pool
+
         if examine_chains:
             self.examine_chains()
 


### PR DESCRIPTION
ptemcee now actually uses the pool object we create in orbitize, rather than creating its own using nthreads