### PR TITLE
Remove unnecessary astroquery imports

### DIFF
--- a/orbitize/results.py
+++ b/orbitize/results.py
@@ -5,9 +5,7 @@ import os
 import astropy.table as table
 
 import orbitize.system
-import orbitize.basis
 import orbitize.plot
-import orbitize.gaia, orbitize.hipparcos
 
 
 class Results(object):
@@ -212,6 +210,7 @@ class Results(object):
 
         iad_data = hf.get("IAD_datafile")
         if iad_data is not None:
+            from orbitize.hipparcos import HipparcosLogProb
 
             tmpfile = 'tmpfile_OkToDeleteAfterFitFinishes'
             with open(tmpfile, 'w+') as f:
@@ -226,7 +225,7 @@ class Results(object):
             alphadec0_epoch = float(hf.attrs['alphadec0_epoch'])
             renormalize_errors = bool(hf.attrs['renormalize_errors'])
 
-            hipparcos_IAD = orbitize.hipparcos.HipparcosLogProb(
+            hipparcos_IAD = HipparcosLogProb(
                 tmpfile,
                 hip_num,
                 num_secondary_bodies,
@@ -238,7 +237,8 @@ class Results(object):
             try:
                 gaia_num = int(hf.attrs['gaia_num'])
                 dr = str(hf.attrs['dr'])
-                gaia = orbitize.gaia.GaiaLogProb(gaia_num, hipparcos_IAD, dr)
+                from orbitize.gaia import GaiaLogProb
+                gaia = GaiaLogProb(gaia_num, hipparcos_IAD, dr)
             except KeyError:
                 gaia = None
 
@@ -250,7 +250,8 @@ class Results(object):
                 tmptbl = table.Table(np.array(gaiagost_data))
                 tmptbl.write(tmpfile, format="ascii", overwrite=True)
 
-                gaia = orbitize.gaia.HGCALogProb(int(hip_num), hipparcos_IAD, tmpfile)
+                from orbitize.gaia import HGCALogProb
+                gaia = HGCALogProb(int(hip_num), hipparcos_IAD, tmpfile)
                 hipparcos_IAD = None # HGCA handles hipparocs, so don't want to pass Hipparcos also into the system
 
 

--- a/tests/test_gaia.py
+++ b/tests/test_gaia.py
@@ -1,25 +1,56 @@
 import numpy as np
 import os
+import contextlib
+from io import StringIO
+import warnings
 from orbitize import DATADIR
 from orbitize import hipparcos, gaia, basis, system, read_input, sampler, results
 
+
+hip_num = "027321"  # beta Pic
+edr3_num = 4792774797545800832
+dr2_number = 4792774797545105664
+
+# Data to use in testing when no internet is available
+gaia_edr3_data = {
+    "ra": 86.82123452009108,
+    "ra_error": 0.13713108,
+    "dec": -51.066136257823345,
+    "dec_error": 0.13109376
+}
+
+gaia_dr2_data = {
+    "ra": 86.82123366090146,
+    "ra_error": 0.3136836085700656,
+    "dec": -51.06614803159093,
+    "dec_error": 0.34165541753173584
+}
+
+output = StringIO()
+with contextlib.redirect_stdout(output):
+    gaia.Gaia.get_status_messages()
+response = output.getvalue()
+offline = False
+if len(response) > 0:
+    warnings.warn("Testing with offline data because Gaia is behaving irregularly: {}".format(response))
+    offline = True
 
 def test_dr2_edr3():
     """
     Test that both DR2 and eDR3 retrieval gives ballpark similar values for
     beta Pic
     """
-    hip_num = "027321"  # beta Pic
-    edr3_num = 4792774797545800832
-    dr2_number = 4792774797545105664
-
     num_secondary_bodies = 1
     path_to_iad_file = "{}HIP{}.d".format(DATADIR, hip_num)
 
     myHip = hipparcos.HipparcosLogProb(path_to_iad_file, hip_num, num_secondary_bodies)
 
-    dr3Gaia = gaia.GaiaLogProb(edr3_num, myHip, dr="edr3")
-    dr2Gaia = gaia.GaiaLogProb(dr2_number, myHip, dr="dr2")
+    if offline:
+        dr3Gaia = gaia.GaiaLogProb(edr3_num, myHip, dr="edr3", query=False, gaia_data=gaia_edr3_data)
+        dr2Gaia = gaia.GaiaLogProb(dr2_number, myHip, dr="dr2", query=False, gaia_data=gaia_dr2_data)
+    else:
+        dr3Gaia = gaia.GaiaLogProb(edr3_num, myHip, dr="edr3")
+        dr2Gaia = gaia.GaiaLogProb(dr2_number, myHip, dr="dr2")
 
     assert np.isclose(dr2Gaia.ra, dr3Gaia.ra, atol=0.1)  # abs tolerance in degrees
 
@@ -28,13 +59,14 @@ def test_system_setup():
     """
     Test that a System object with Hipparcos and Gaia is initialized correctly
     """
-    hip_num = "027321"  # beta Pic
-    edr3_num = 4792774797545800832
     num_secondary_bodies = 1
     path_to_iad_file = "{}HIP{}.d".format(DATADIR, hip_num)
 
     myHip = hipparcos.HipparcosLogProb(path_to_iad_file, hip_num, num_secondary_bodies)
-    myGaia = gaia.GaiaLogProb(edr3_num, myHip, dr="edr3")
+    if offline:
+        myGaia = gaia.GaiaLogProb(edr3_num, myHip, dr="edr3",  query=False, gaia_data=gaia_edr3_data)
+    else:
+        myGaia = gaia.GaiaLogProb(edr3_num, myHip, dr="edr3")
 
     input_file = os.path.join(DATADIR, "betaPic.csv")
     plx = 51.5
@@ -78,8 +110,6 @@ def test_valueerror():
     """
     Check that if I don't say dr2 or edr3, I get a value error
     """
-    hip_num = "027321"  # beta Pic
-    edr3_num = 4792774797545800832
     num_secondary_bodies = 1
     path_to_iad_file = "{}HIP{}.d".format(DATADIR, hip_num)
 
@@ -121,13 +151,14 @@ def test_orbit_calculation():
     a0 = 0
     d0 = 0
 
-    hip_num = "027321"  # beta Pic
-    edr3_num = 4792774797545800832
     num_secondary_bodies = 1
     path_to_iad_file = "{}HIP{}.d".format(DATADIR, hip_num)
 
     myHip = hipparcos.HipparcosLogProb(path_to_iad_file, hip_num, num_secondary_bodies)
-    myGaia = gaia.GaiaLogProb(edr3_num, myHip, dr="edr3")
+    if offline:
+        myGaia = gaia.GaiaLogProb(edr3_num, myHip, dr="edr3", query=False, gaia_data=gaia_edr3_data)
+    else:
+        myGaia = gaia.GaiaLogProb(edr3_num, myHip, dr="edr3")
 
     param_idx = {
         "sma1": 0,
@@ -225,7 +256,7 @@ def test_hgca():
     gost_filepath = os.path.join(DATADIR, "gaia_edr3_betpic_epochs.csv")
     astrometry_filepath = os.path.join(DATADIR, "betaPic.csv")
 
-    hipparcos_lnprob = hipparcos.HipparcosLogProb(iad_filepath, "027321", 1)
+    hipparcos_lnprob = hipparcos.HipparcosLogProb(iad_filepath, hip_num, 1)
     hgca_lnprob = gaia.HGCALogProb(27321, hipparcos_lnprob, gost_filepath)
 
     # test a few things were read in correctly
@@ -307,7 +338,7 @@ def test_nointernet():
 
 
 if __name__ == "__main__":
-    test_nointernet()
+    # test_nointernet()
     # test_dr2_edr3()
     # test_system_setup()
     # test_valueerror()

--- a/tests/test_hipparcos.py
+++ b/tests/test_hipparcos.py
@@ -1,10 +1,18 @@
 import numpy as np
 import os
+import io
+import contextlib
+import pytest
 
 from orbitize import DATADIR, read_input, system, sampler, results
-from orbitize.gaia import GaiaLogProb
+from orbitize import gaia
 from orbitize.hipparcos import HipparcosLogProb, nielsen_iad_refitting_test
 
+output = io.StringIO()
+with contextlib.redirect_stdout(output):
+    gaia.Gaia.get_status_messages()
+response = output.getvalue()
+offline = len(response) > 0
 
 def test_hipparcos_api():
     """
@@ -180,7 +188,9 @@ def test_save_load_dvd():
     path_to_iad_file = "{}HIP{}.d".format(DATADIR, hip_num)
 
     myHip = HipparcosLogProb(path_to_iad_file, hip_num, num_secondary_bodies)
-    myGaia = GaiaLogProb(4792774797545800832, myHip, dr="edr3")
+    if offline:
+        pytest.skip("Gaia is behaving irregularly: {}".format(response))
+    myGaia = gaia.GaiaLogProb(4792774797545800832, myHip, dr="edr3")
 
     input_file = os.path.join(DATADIR, "HD4747.csv")
     data_table_with_rvs = read_input.read_file(input_file)
@@ -225,7 +235,9 @@ def test_save_load_2021():
     path_to_iad_file = "{}H{}.d".format(DATADIR, hip_num)
 
     myHip = HipparcosLogProb(path_to_iad_file, hip_num, num_secondary_bodies)
-    myGaia = GaiaLogProb(4792774797545800832, myHip, dr="edr3")
+    if offline:
+        pytest.skip("Gaia is behaving irregularly: {}".format(response))
+    myGaia = gaia.GaiaLogProb(4792774797545800832, myHip, dr="edr3")
 
     input_file = os.path.join(DATADIR, "HD4747.csv")
     data_table_with_rvs = read_input.read_file(input_file)

--- a/tests/test_results.py
+++ b/tests/test_results.py
@@ -6,6 +6,8 @@ import orbitize
 from orbitize import results, read_input, system, DATADIR, hipparcos, gaia, sampler
 import numpy as np
 import pytest
+import io
+import contextlib
 import os
 
 std_labels = ["sma1", "ecc1", "inc1", "aop1", "pan1", "tau1", "plx", "mtot"]
@@ -293,7 +295,13 @@ def test_save_and_load_gaia_and_hipparcos():
     Test that a Results object for a Gaia+Hipparcos fit
     is saved and loaded properly.
     """
-
+    output = io.StringIO()
+    with contextlib.redirect_stdout(output):
+        gaia.Gaia.get_status_messages()
+    response = output.getvalue()
+    if len(response) > 0:
+        pytest.skip("Gaia is behaving irregularly: {}".format(response))
+    
     hip_num = "027321"
     gaia_num = 4792774797545105664
     num_secondary_bodies = 1


### PR DESCRIPTION
Only import modules which require `astroquery` when necessary to not get stuck when the internet/archive are very slow. Has been tested with the Gaia archive being online, slow, and down.